### PR TITLE
08.2 Publish UserRegistered and fix RabbitMQ integration test

### DIFF
--- a/src/main/tv/codely/scala_http_api/entry_point/ScalaHttpApi.scala
+++ b/src/main/tv/codely/scala_http_api/entry_point/ScalaHttpApi.scala
@@ -31,7 +31,7 @@ object ScalaHttpApi {
     implicit val executionContext: ExecutionContext = sharedDependencies.executionContext
 
     val container = new EntryPointDependencyContainer(
-      new UserModuleDependencyContainer(sharedDependencies.doobieDbConnection),
+      new UserModuleDependencyContainer(sharedDependencies.doobieDbConnection, sharedDependencies.messagePublisher),
       new VideoModuleDependencyContainer(sharedDependencies.doobieDbConnection, sharedDependencies.messagePublisher)
     )
 

--- a/src/main/tv/codely/scala_http_api/module/shared/infrastructure/dependency_injection/SharedModuleDependencyContainer.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/infrastructure/dependency_injection/SharedModuleDependencyContainer.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import tv.codely.scala_http_api.module.shared.domain.MessagePublisher
 import tv.codely.scala_http_api.module.shared.infrastructure.config.{DbConfig, MessageBrokerConfig}
-import tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq.RabbitMqMessagePublisher
+import tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq.{RabbitMqChannelFactory, RabbitMqMessagePublisher}
 import tv.codely.scala_http_api.module.shared.infrastructure.persistence.doobie.DoobieDbConnection
 
 import scala.concurrent.ExecutionContext
@@ -19,5 +19,7 @@ final class SharedModuleDependencyContainer(
   val executionContext: ExecutionContext = actorSystem.dispatcher
 
   val doobieDbConnection: DoobieDbConnection = new DoobieDbConnection(dbConfig)
-  val messagePublisher: MessagePublisher     = new RabbitMqMessagePublisher(publisherConfig)
+
+  private val rabbitMqChannelFactory     = new RabbitMqChannelFactory(publisherConfig)
+  val messagePublisher: MessagePublisher = new RabbitMqMessagePublisher(rabbitMqChannelFactory)
 }

--- a/src/main/tv/codely/scala_http_api/module/shared/infrastructure/marshaller/MessageJsonFormatMarshaller.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/infrastructure/marshaller/MessageJsonFormatMarshaller.scala
@@ -3,18 +3,22 @@ package tv.codely.scala_http_api.module.shared.infrastructure.marshaller
 import spray.json._
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, RootJsonFormat, SerializationException}
 import tv.codely.scala_http_api.module.shared.domain.Message
+import tv.codely.scala_http_api.module.user.domain.UserRegistered
 import tv.codely.scala_http_api.module.video.domain.VideoCreated
 import tv.codely.scala_http_api.module.video.infrastructure.marshaller.VideoCreatedJsonFormatMarshaller._
+import tv.codely.scala_http_api.module.user.infrastructure.marshaller.UserRegisteredJsonFormatMarshaller._
 
 object MessageJsonFormatMarshaller extends DefaultJsonProtocol {
   implicit object MessageMarshaller extends RootJsonFormat[Message] {
     override def write(m: Message): JsValue = m match {
-      case vc: VideoCreated => vc.toJson
-      case unknown          => throw new SerializationException(s"Unknown message type to write <${unknown.getClass}>")
+      case vc: VideoCreated   => vc.toJson
+      case ur: UserRegistered => ur.toJson
+      case unknown            => throw new SerializationException(s"Unknown message type to write <${unknown.getClass}>")
     }
 
     override def read(jv: JsValue): Message = jv.asJsObject.getFields("type") match {
-      case Seq(JsString("codelytv_scala_api.video_created")) => jv.convertTo[VideoCreated]
+      case Seq(JsString("codelytv_scala_api.video_created"))   => jv.convertTo[VideoCreated]
+      case Seq(JsString("codelytv_scala_api.user_registered")) => jv.convertTo[UserRegistered]
       case Seq(JsString(unknown)) =>
         throw DeserializationException(s"Unknown message type to read <$unknown>")
     }

--- a/src/main/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqChannelFactory.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqChannelFactory.scala
@@ -1,0 +1,19 @@
+package tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq
+
+import com.newmotion.akka.rabbitmq.ConnectionFactory
+import com.rabbitmq.client.Channel
+import tv.codely.scala_http_api.module.shared.infrastructure.config.MessageBrokerConfig
+
+final class RabbitMqChannelFactory(config: MessageBrokerConfig) {
+  val channel: Channel = {
+    val factory = new ConnectionFactory()
+    factory.setHost(config.host)
+    factory.setPort(config.port)
+    factory.setUsername(config.user)
+    factory.setPassword(config.password)
+
+    val connection = factory.newConnection()
+
+    connection.createChannel()
+  }
+}

--- a/src/main/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePublisher.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePublisher.scala
@@ -1,19 +1,11 @@
 package tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq
 
-import com.newmotion.akka.rabbitmq._
 import com.rabbitmq.client.MessageProperties
 import tv.codely.scala_http_api.module.shared.domain.{Message, MessagePublisher}
-import tv.codely.scala_http_api.module.shared.infrastructure.config.MessageBrokerConfig
 import tv.codely.scala_http_api.module.shared.infrastructure.marshaller.MessageJsonFormatMarshaller.MessageMarshaller
 
-final class RabbitMqMessagePublisher(publisherConfig: MessageBrokerConfig) extends MessagePublisher {
-  private val factory = new ConnectionFactory()
-  factory.setHost(publisherConfig.host)
-  factory.setPort(publisherConfig.port)
-  factory.setUsername(publisherConfig.user)
-  factory.setPassword(publisherConfig.password)
-  private val connection = factory.newConnection()
-  private val channel    = connection.createChannel()
+final class RabbitMqMessagePublisher(channelFactory: RabbitMqChannelFactory) extends MessagePublisher {
+  private val channel = channelFactory.channel
 
   // Use the default nameless exchange in order to route the published messages based on
   // the mapping between the message routing key and the queue names.

--- a/src/main/tv/codely/scala_http_api/module/user/application/register/UserRegisterer.scala
+++ b/src/main/tv/codely/scala_http_api/module/user/application/register/UserRegisterer.scala
@@ -1,11 +1,14 @@
 package tv.codely.scala_http_api.module.user.application.register
 
-import tv.codely.scala_http_api.module.user.domain.{User, UserId, UserName, UserRepository}
+import tv.codely.scala_http_api.module.shared.domain.MessagePublisher
+import tv.codely.scala_http_api.module.user.domain._
 
-final class UserRegisterer(repository: UserRepository) {
+final class UserRegisterer(repository: UserRepository, publisher: MessagePublisher) {
   def register(id: UserId, name: UserName): Unit = {
     val user = User(id, name)
 
     repository.save(user)
+
+    publisher.publish(UserRegistered(user))
   }
 }

--- a/src/main/tv/codely/scala_http_api/module/user/domain/UserRegistered.scala
+++ b/src/main/tv/codely/scala_http_api/module/user/domain/UserRegistered.scala
@@ -1,0 +1,13 @@
+package tv.codely.scala_http_api.module.user.domain
+
+import tv.codely.scala_http_api.module.shared.domain.Message
+
+object UserRegistered {
+  def apply(id: String, name: String): UserRegistered = apply(UserId(id), UserName(name))
+
+  def apply(user: User): UserRegistered = apply(user.id, user.name)
+}
+
+final case class UserRegistered(id: UserId, name: UserName) extends Message {
+  override val subType: String = "user_registered"
+}

--- a/src/main/tv/codely/scala_http_api/module/user/infrastructure/dependency_injection/UserModuleDependencyContainer.scala
+++ b/src/main/tv/codely/scala_http_api/module/user/infrastructure/dependency_injection/UserModuleDependencyContainer.scala
@@ -1,5 +1,6 @@
 package tv.codely.scala_http_api.module.user.infrastructure.dependency_injection
 
+import tv.codely.scala_http_api.module.shared.domain.MessagePublisher
 import tv.codely.scala_http_api.module.shared.infrastructure.persistence.doobie.DoobieDbConnection
 import tv.codely.scala_http_api.module.user.application.register.UserRegisterer
 import tv.codely.scala_http_api.module.user.application.search.UsersSearcher
@@ -9,10 +10,11 @@ import tv.codely.scala_http_api.module.user.infrastructure.repository.DoobieMySq
 import scala.concurrent.ExecutionContext
 
 final class UserModuleDependencyContainer(
-    doobieDbConnection: DoobieDbConnection
+    doobieDbConnection: DoobieDbConnection,
+    messagePublisher: MessagePublisher
 )(implicit executionContext: ExecutionContext) {
   val repository: UserRepository = new DoobieMySqlUserRepository(doobieDbConnection)
 
   val usersSearcher: UsersSearcher   = new UsersSearcher(repository)
-  val userRegisterer: UserRegisterer = new UserRegisterer(repository)
+  val userRegisterer: UserRegisterer = new UserRegisterer(repository, messagePublisher)
 }

--- a/src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserAttributesJsonFormatMarshaller.scala
+++ b/src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserAttributesJsonFormatMarshaller.scala
@@ -1,0 +1,25 @@
+package tv.codely.scala_http_api.module.user.infrastructure.marshaller
+
+import java.util.UUID
+
+import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
+import tv.codely.scala_http_api.module.shared.infrastructure.marshaller.UuidJsonFormatMarshaller._
+import tv.codely.scala_http_api.module.user.domain.{UserId, UserName}
+import spray.json._
+
+object UserAttributesJsonFormatMarshaller extends DefaultJsonProtocol {
+  implicit object UserIdMarshaller extends JsonFormat[UserId] {
+    override def write(value: UserId): JsValue = value.value.toJson
+
+    override def read(value: JsValue): UserId = UserId(value.convertTo[UUID])
+  }
+
+  implicit object UserNameMarshaller extends JsonFormat[UserName] {
+    override def write(value: UserName): JsValue = JsString(value.value)
+
+    override def read(value: JsValue): UserName = value match {
+      case JsString(name) => UserName(name)
+      case _              => throw DeserializationException("Expected 1 string for UserName")
+    }
+  }
+}

--- a/src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserJsonFormatMarshaller.scala
+++ b/src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserJsonFormatMarshaller.scala
@@ -1,27 +1,9 @@
 package tv.codely.scala_http_api.module.user.infrastructure.marshaller
 
-import java.util.UUID
-
-import spray.json.{DeserializationException, JsString, JsValue, JsonFormat, RootJsonFormat}
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 import tv.codely.scala_http_api.module.user.domain.{User, UserId, UserName}
-import tv.codely.scala_http_api.module.shared.infrastructure.marshaller.UuidJsonFormatMarshaller._
-import spray.json._
+import UserAttributesJsonFormatMarshaller._
 
 object UserJsonFormatMarshaller extends DefaultJsonProtocol {
-  implicit object UserIdMarshaller extends JsonFormat[UserId] {
-    override def write(value: UserId): JsValue = value.value.toJson
-
-    override def read(value: JsValue): UserId = UserId(value.convertTo[UUID])
-  }
-
-  implicit object UserNameMarshaller extends JsonFormat[UserName] {
-    override def write(value: UserName): JsValue = JsString(value.value)
-
-    override def read(value: JsValue): UserName = value match {
-      case JsString(name) => UserName(name)
-      case _              => throw DeserializationException("Expected 1 string for UserName")
-    }
-  }
-
   implicit val userFormat: RootJsonFormat[User] = jsonFormat2(User.apply(_: UserId, _: UserName))
 }

--- a/src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserRegisteredJsonFormatMarshaller.scala
+++ b/src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserRegisteredJsonFormatMarshaller.scala
@@ -1,0 +1,22 @@
+package tv.codely.scala_http_api.module.user.infrastructure.marshaller
+
+import spray.json.{DefaultJsonProtocol, DeserializationException, JsObject, JsString, JsValue, RootJsonFormat}
+import tv.codely.scala_http_api.module.user.domain.UserRegistered
+import UserAttributesJsonFormatMarshaller._
+import spray.json._
+
+object UserRegisteredJsonFormatMarshaller extends DefaultJsonProtocol {
+  implicit object UserRegisteredJsonFormat extends RootJsonFormat[UserRegistered] {
+    override def write(ur: UserRegistered): JsValue = JsObject(
+      "type" -> JsString(ur.`type`),
+      "id"   -> ur.id.toJson,
+      "name" -> ur.name.toJson
+    )
+
+    override def read(value: JsValue): UserRegistered =
+      value.asJsObject.getFields("id", "name") match {
+        case Seq(JsString(id), JsString(name)) => UserRegistered(id, name)
+        case unknown                           => throw DeserializationException(s"Error reading VideoCreated JSON <$unknown>")
+      }
+  }
+}

--- a/src/main/tv/codely/scala_http_api/module/video/application/create/VideoCreator.scala
+++ b/src/main/tv/codely/scala_http_api/module/video/application/create/VideoCreator.scala
@@ -7,8 +7,8 @@ final class VideoCreator(repository: VideoRepository, publisher: MessagePublishe
   def create(id: VideoId, title: VideoTitle, duration: VideoDuration, category: VideoCategory): Unit = {
     val video = Video(id, title, duration, category)
 
-    publisher.publish(VideoCreated(video))
-
     repository.save(video)
+
+    publisher.publish(VideoCreated(video))
   }
 }

--- a/src/main/tv/codely/scala_http_api/module/video/infrastructure/marshaller/VideoAttributesJsonFormatMarshaller.scala
+++ b/src/main/tv/codely/scala_http_api/module/video/infrastructure/marshaller/VideoAttributesJsonFormatMarshaller.scala
@@ -1,11 +1,10 @@
-package tv.codely.scala_http_api.module.shared.infrastructure.marshaller
+package tv.codely.scala_http_api.module.video.infrastructure.marshaller
 
 import java.util.UUID
 
-import spray.json.{DeserializationException, JsNumber, JsString, JsValue, JsonFormat}
-import tv.codely.scala_http_api.module.video.domain._
+import spray.json.{DeserializationException, JsNumber, JsString, JsValue, JsonFormat, _}
 import tv.codely.scala_http_api.module.shared.infrastructure.marshaller.UuidJsonFormatMarshaller._
-import spray.json._
+import tv.codely.scala_http_api.module.video.domain._
 
 object VideoAttributesJsonFormatMarshaller {
   implicit object VideoIdMarshaller extends JsonFormat[VideoId] {

--- a/src/main/tv/codely/scala_http_api/module/video/infrastructure/marshaller/VideoCreatedJsonFormatMarshaller.scala
+++ b/src/main/tv/codely/scala_http_api/module/video/infrastructure/marshaller/VideoCreatedJsonFormatMarshaller.scala
@@ -2,7 +2,7 @@ package tv.codely.scala_http_api.module.video.infrastructure.marshaller
 
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, RootJsonFormat}
 import tv.codely.scala_http_api.module.video.domain._
-import tv.codely.scala_http_api.module.shared.infrastructure.marshaller.VideoAttributesJsonFormatMarshaller._
+import VideoAttributesJsonFormatMarshaller._
 import spray.json._
 
 object VideoCreatedJsonFormatMarshaller extends DefaultJsonProtocol {

--- a/src/main/tv/codely/scala_http_api/module/video/infrastructure/marshaller/VideoJsonFormatMarshaller.scala
+++ b/src/main/tv/codely/scala_http_api/module/video/infrastructure/marshaller/VideoJsonFormatMarshaller.scala
@@ -1,7 +1,7 @@
 package tv.codely.scala_http_api.module.video.infrastructure.marshaller
 
 import spray.json.{DefaultJsonProtocol, RootJsonFormat}
-import tv.codely.scala_http_api.module.shared.infrastructure.marshaller.VideoAttributesJsonFormatMarshaller._
+import VideoAttributesJsonFormatMarshaller._
 import tv.codely.scala_http_api.module.video.domain._
 
 object VideoJsonFormatMarshaller extends DefaultJsonProtocol {

--- a/src/test/tv/codely/scala_http_api/entry_point/AcceptanceSpec.scala
+++ b/src/test/tv/codely/scala_http_api/entry_point/AcceptanceSpec.scala
@@ -25,7 +25,10 @@ protected[entry_point] abstract class AcceptanceSpec
 
   private val sharedDependencies = new SharedModuleDependencyContainer(actorSystemName, dbConfig, publisherConfig)
 
-  protected val userDependencies = new UserModuleDependencyContainer(sharedDependencies.doobieDbConnection)
+  protected val userDependencies = new UserModuleDependencyContainer(
+    sharedDependencies.doobieDbConnection,
+    sharedDependencies.messagePublisher
+  )
   protected val videoDependencies = new VideoModuleDependencyContainer(
     sharedDependencies.doobieDbConnection,
     sharedDependencies.messagePublisher

--- a/src/test/tv/codely/scala_http_api/module/IntegrationTestCase.scala
+++ b/src/test/tv/codely/scala_http_api/module/IntegrationTestCase.scala
@@ -4,7 +4,6 @@ import com.typesafe.config.ConfigFactory
 import tv.codely.scala_http_api.module.shared.domain.MessagePublisher
 import tv.codely.scala_http_api.module.shared.infrastructure.config.{DbConfig, MessageBrokerConfig}
 import tv.codely.scala_http_api.module.shared.infrastructure.dependency_injection.SharedModuleDependencyContainer
-import tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq.{MessageConsumer, RabbitMqMessageConsumer}
 import tv.codely.scala_http_api.module.shared.infrastructure.persistence.doobie.DoobieDbConnection
 
 import scala.concurrent.ExecutionContext
@@ -12,9 +11,9 @@ import scala.concurrent.ExecutionContext
 protected[scala_http_api] trait IntegrationTestCase extends UnitTestCase {
   private val actorSystemName = "scala-http-api-integration-test"
 
-  private val appConfig       = ConfigFactory.load("application")
-  private val dbConfig        = DbConfig(appConfig.getConfig("database"))
-  private val publisherConfig = MessageBrokerConfig(appConfig.getConfig("message-publisher"))
+  private val appConfig         = ConfigFactory.load("application")
+  private val dbConfig          = DbConfig(appConfig.getConfig("database"))
+  protected val publisherConfig = MessageBrokerConfig(appConfig.getConfig("message-publisher"))
 
   private val sharedDependencies = new SharedModuleDependencyContainer(actorSystemName, dbConfig, publisherConfig)
 
@@ -22,7 +21,4 @@ protected[scala_http_api] trait IntegrationTestCase extends UnitTestCase {
 
   protected val doobieDbConnection: DoobieDbConnection = sharedDependencies.doobieDbConnection
   protected val messagePublisher: MessagePublisher     = sharedDependencies.messagePublisher
-
-  protected val videoCreatedQueueConsumer: MessageConsumer =
-    new RabbitMqMessageConsumer(publisherConfig)("codelytv_scala_api.video_created")
 }

--- a/src/test/tv/codely/scala_http_api/module/IntegrationTestCase.scala
+++ b/src/test/tv/codely/scala_http_api/module/IntegrationTestCase.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import tv.codely.scala_http_api.module.shared.domain.MessagePublisher
 import tv.codely.scala_http_api.module.shared.infrastructure.config.{DbConfig, MessageBrokerConfig}
 import tv.codely.scala_http_api.module.shared.infrastructure.dependency_injection.SharedModuleDependencyContainer
+import tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq.RabbitMqChannelFactory
 import tv.codely.scala_http_api.module.shared.infrastructure.persistence.doobie.DoobieDbConnection
 
 import scala.concurrent.ExecutionContext
@@ -11,14 +12,15 @@ import scala.concurrent.ExecutionContext
 protected[scala_http_api] trait IntegrationTestCase extends UnitTestCase {
   private val actorSystemName = "scala-http-api-integration-test"
 
-  private val appConfig         = ConfigFactory.load("application")
-  private val dbConfig          = DbConfig(appConfig.getConfig("database"))
-  protected val publisherConfig = MessageBrokerConfig(appConfig.getConfig("message-publisher"))
+  private val appConfig       = ConfigFactory.load("application")
+  private val dbConfig        = DbConfig(appConfig.getConfig("database"))
+  private val publisherConfig = MessageBrokerConfig(appConfig.getConfig("message-publisher"))
 
   private val sharedDependencies = new SharedModuleDependencyContainer(actorSystemName, dbConfig, publisherConfig)
 
   implicit protected val executionContext: ExecutionContext = sharedDependencies.executionContext
 
-  protected val doobieDbConnection: DoobieDbConnection = sharedDependencies.doobieDbConnection
-  protected val messagePublisher: MessagePublisher     = sharedDependencies.messagePublisher
+  protected val doobieDbConnection: DoobieDbConnection         = sharedDependencies.doobieDbConnection
+  protected val rabbitMqChannelFactory: RabbitMqChannelFactory = new RabbitMqChannelFactory(publisherConfig)
+  protected val messagePublisher: MessagePublisher             = sharedDependencies.messagePublisher
 }

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/MessageConsumer.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/MessageConsumer.scala
@@ -4,6 +4,6 @@ import tv.codely.scala_http_api.module.shared.domain.Message
 
 trait MessageConsumer {
   def startConsuming(handler: Message => Boolean): Unit
-  def hasMessages: Boolean
-  def isEmpty: Boolean = !hasMessages
+  def hasMessagesToConsume: Boolean
+  def isEmpty: Boolean = !hasMessagesToConsume
 }

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/MessagePurger.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/MessagePurger.scala
@@ -1,0 +1,5 @@
+package tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq
+
+trait MessagePurger {
+  def purgeQueue(): Unit
+}

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessageConsumer.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessageConsumer.scala
@@ -1,18 +1,11 @@
 package tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq
-import com.newmotion.akka.rabbitmq.{BasicProperties, ConnectionFactory, DefaultConsumer, Envelope}
+import com.newmotion.akka.rabbitmq.{BasicProperties, DefaultConsumer, Envelope}
 import tv.codely.scala_http_api.module.shared.domain.Message
-import tv.codely.scala_http_api.module.shared.infrastructure.config.MessageBrokerConfig
 import tv.codely.scala_http_api.module.shared.infrastructure.marshaller.MessageJsonFormatMarshaller._
 import spray.json._
 
-final class RabbitMqMessageConsumer(brokerConfig: MessageBrokerConfig)(queueName: String) extends MessageConsumer {
-  private val factory = new ConnectionFactory()
-  factory.setHost(brokerConfig.host)
-  factory.setPort(brokerConfig.port)
-  factory.setUsername(brokerConfig.user)
-  factory.setPassword(brokerConfig.password)
-  private val connection = factory.newConnection()
-  private val channel    = connection.createChannel()
+final class RabbitMqMessageConsumer(channelFactory: RabbitMqChannelFactory)(queueName: String) extends MessageConsumer {
+  private val channel = channelFactory.channel
 
   override def startConsuming(handler: Message => Boolean): Unit = {
     val consumer = new DefaultConsumer(channel) {

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessageConsumer.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessageConsumer.scala
@@ -38,5 +38,5 @@ final class RabbitMqMessageConsumer(brokerConfig: MessageBrokerConfig)(queueName
     channel.basicConsume(queueName, autoAckAfterConsume, consumer).map(_ => ())
   }
 
-  override def hasMessages: Boolean = channel.messageCount(queueName) > 0
+  override def hasMessagesToConsume: Boolean = channel.messageCount(queueName) > 0
 }

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePublisherShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePublisherShould.scala
@@ -5,31 +5,49 @@ import tv.codely.scala_http_api.module.IntegrationTestCase
 import tv.codely.scala_http_api.module.shared.domain.Message
 import tv.codely.scala_http_api.module.video.domain.VideoCreatedStub
 
+import scala.collection.mutable
 import scala.concurrent.duration._
 
 final class RabbitMqMessagePublisherShould extends IntegrationTestCase with Eventually {
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 1.second, interval = 50.millis)
 
-  // @ToDo: Fix this test. Since the `MessagePublisher` publishes out the event asynchronously,
-  // we validate that the queue is empty even before publishing the event.
-  // Furthermore, the `assertConsumes` assertion could contain an invalid actual result that it will not fail.
+  private val queueName                                  = "codelytv_scala_api.video_created"
+  private val videoCreatedQueuePurger: MessagePurger     = new RabbitMqMessagePurger(publisherConfig)(queueName)
+  private val videoCreatedQueueConsumer: MessageConsumer = new RabbitMqMessageConsumer(publisherConfig)(queueName)
+
+  private val consumedMessages: mutable.Buffer[Message] = mutable.Buffer.empty
+
   "publish VideoCreated domain events" in {
-    val videoCreated = VideoCreatedStub.random
-
-    messagePublisher.publish(videoCreated)
-
-    videoCreatedQueueConsumer.startConsuming(handler = assertConsumes(videoCreated))
-
+    videoCreatedQueuePurger.purgeQueue()
     waitUntilQueueIsEmpty()
+
+    val videoCreated = VideoCreatedStub.random
+    messagePublisher.publish(videoCreated)
+    waitUntilQueueHasMessages()
+
+    videoCreatedQueueConsumer.startConsuming(extractConsumedMessagesHandler)
+    waitUntilQueueIsEmpty()
+
+    consumedMessages.synchronized(consumedMessages shouldBe Seq(videoCreated))
   }
 
-  private def assertConsumes(expectedMessage: Message)(consumedMessage: Message): Boolean = {
-    consumedMessage shouldBe expectedMessage
-    true
+  private def extractConsumedMessagesHandler(consumedMessage: Message): Boolean = {
+    consumedMessages.synchronized(consumedMessages += consumedMessage)
+    val handledSuccessfully = true
+    handledSuccessfully
   }
+
+  private def waitUntilQueueHasMessages(): Unit = eventually(
+    if (videoCreatedQueueConsumer.hasMessagesToConsume) ()
+    else throw new RuntimeException("Queue has no messages. Waiting a little bit more…")
+  )
 
   private def waitUntilQueueIsEmpty(): Unit = eventually(
-    if (videoCreatedQueueConsumer.isEmpty) ()
-    else throw new RuntimeException("Queue is not empty. Waiting a little bit more…")
+    if (videoCreatedQueueConsumer.isEmpty) {
+      // If the RabbitMQ queue doesn't has any message, it doesn't mean we're not processing the last ones.
+      // Wait a little in order to let consuming and acknowledge these messages.
+      // More info under the `message-count` domain concept: https://www.rabbitmq.com/amqp-0-9-1-reference.html#domains
+      Thread.sleep(50)
+    } else throw new RuntimeException("Queue is not empty. Waiting a little bit more…")
   )
 }

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePublisherShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePublisherShould.scala
@@ -11,9 +11,10 @@ import scala.concurrent.duration._
 final class RabbitMqMessagePublisherShould extends IntegrationTestCase with Eventually {
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 1.second, interval = 50.millis)
 
-  private val queueName                                  = "codelytv_scala_api.video_created"
-  private val videoCreatedQueuePurger: MessagePurger     = new RabbitMqMessagePurger(publisherConfig)(queueName)
-  private val videoCreatedQueueConsumer: MessageConsumer = new RabbitMqMessageConsumer(publisherConfig)(queueName)
+  private val queueName                              = "codelytv_scala_api.video_created"
+  private val videoCreatedQueuePurger: MessagePurger = new RabbitMqMessagePurger(rabbitMqChannelFactory)(queueName)
+  private val videoCreatedQueueConsumer: MessageConsumer =
+    new RabbitMqMessageConsumer(rabbitMqChannelFactory)(queueName)
 
   private val consumedMessages: mutable.Buffer[Message] = mutable.Buffer.empty
 

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePurger.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePurger.scala
@@ -1,0 +1,16 @@
+package tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq
+
+import com.newmotion.akka.rabbitmq.ConnectionFactory
+import tv.codely.scala_http_api.module.shared.infrastructure.config.MessageBrokerConfig
+
+final class RabbitMqMessagePurger(brokerConfig: MessageBrokerConfig)(queueName: String) extends MessagePurger {
+  private val factory = new ConnectionFactory()
+  factory.setHost(brokerConfig.host)
+  factory.setPort(brokerConfig.port)
+  factory.setUsername(brokerConfig.user)
+  factory.setPassword(brokerConfig.password)
+  private val connection = factory.newConnection()
+  private val channel    = connection.createChannel()
+
+  override def purgeQueue(): Unit = channel.queuePurge(queueName)
+}

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePurger.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePurger.scala
@@ -1,16 +1,7 @@
 package tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq
 
-import com.newmotion.akka.rabbitmq.ConnectionFactory
-import tv.codely.scala_http_api.module.shared.infrastructure.config.MessageBrokerConfig
-
-final class RabbitMqMessagePurger(brokerConfig: MessageBrokerConfig)(queueName: String) extends MessagePurger {
-  private val factory = new ConnectionFactory()
-  factory.setHost(brokerConfig.host)
-  factory.setPort(brokerConfig.port)
-  factory.setUsername(brokerConfig.user)
-  factory.setPassword(brokerConfig.password)
-  private val connection = factory.newConnection()
-  private val channel    = connection.createChannel()
+final class RabbitMqMessagePurger(channelFactory: RabbitMqChannelFactory)(queueName: String) extends MessagePurger {
+  private val channel = channelFactory.channel
 
   override def purgeQueue(): Unit = channel.queuePurge(queueName)
 }

--- a/src/test/tv/codely/scala_http_api/module/user/UserIntegrationTestCase.scala
+++ b/src/test/tv/codely/scala_http_api/module/user/UserIntegrationTestCase.scala
@@ -5,7 +5,7 @@ import tv.codely.scala_http_api.module.user.domain.UserRepository
 import tv.codely.scala_http_api.module.user.infrastructure.dependency_injection.UserModuleDependencyContainer
 
 protected[user] trait UserIntegrationTestCase extends IntegrationTestCase {
-  private val container = new UserModuleDependencyContainer(doobieDbConnection)
+  private val container = new UserModuleDependencyContainer(doobieDbConnection, messagePublisher)
 
   protected val repository: UserRepository = container.repository
 }

--- a/src/test/tv/codely/scala_http_api/module/user/application/register/UserRegistererShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/user/application/register/UserRegistererShould.scala
@@ -8,7 +8,7 @@ final class UserRegistererShould extends UserUnitTestCase with MessagePublisherM
   private val registerer = new UserRegisterer(repository, messagePublisher)
 
   "register a user" in {
-    val user = UserStub.random
+    val user           = UserStub.random
     val userRegistered = UserRegisteredStub(user)
 
     repositoryShouldSave(user)

--- a/src/test/tv/codely/scala_http_api/module/user/application/register/UserRegistererShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/user/application/register/UserRegistererShould.scala
@@ -1,15 +1,19 @@
 package tv.codely.scala_http_api.module.user.application.register
 
+import tv.codely.scala_http_api.module.shared.infrastructure.MessagePublisherMock
 import tv.codely.scala_http_api.module.user.UserUnitTestCase
-import tv.codely.scala_http_api.module.user.domain.UserStub
+import tv.codely.scala_http_api.module.user.domain.{UserRegisteredStub, UserStub}
 
-final class UserRegistererShould extends UserUnitTestCase {
-  private val registerer = new UserRegisterer(repository)
+final class UserRegistererShould extends UserUnitTestCase with MessagePublisherMock {
+  private val registerer = new UserRegisterer(repository, messagePublisher)
 
-  "save a user" in {
+  "register a user" in {
     val user = UserStub.random
+    val userRegistered = UserRegisteredStub(user)
 
     repositoryShouldSave(user)
+
+    publisherShouldPublish(userRegistered)
 
     registerer.register(user.id, user.name).shouldBe(())
   }

--- a/src/test/tv/codely/scala_http_api/module/user/domain/UserRegisteredStub.scala
+++ b/src/test/tv/codely/scala_http_api/module/user/domain/UserRegisteredStub.scala
@@ -1,0 +1,12 @@
+package tv.codely.scala_http_api.module.user.domain
+
+object UserRegisteredStub {
+  def apply(
+      id: UserId = UserIdStub.random,
+      name: UserName = UserNameStub.random
+  ): UserRegistered = UserRegistered(id, name)
+
+  def apply(user: User): UserRegistered = apply(user.id, user.name)
+
+  def random: UserRegistered = apply()
+}


### PR DESCRIPTION
⚠️ Dependent PR: #6, #7, #8, #9 & #10 ⚠️

* Publish UserRegistered domain event
* Fix `RabbitMqMessagePublisherShould` test.
  * Purge the queue before performing the test in order to avoid consuming previously published events such as the ones coming from the acceptance tests.
  * Since the `MessagePublisher` publishes out the messages asynchronously, we were validating that the queue was empty even before publishing the message, so we were not really waiting for the message to be consumed before asserting that the consumed message was the expected one. Now we wait until the queue has messages before starting to consume.
  * The previous assertion was running in another thread and, since the default exception handler used by the RabbitMQ library is an implementation which catches the exceptions and traduce them into a log error (https://github.com/rabbitmq/rabbitmq-java-client/pull/74), the test was never failing (only logging errors). Now we inject from the test to the messages consumer a handler which extracts the event into a synchronized `mutable.Buffer` in order to perform the assertions proving that the consumed messages are the ones we're really expecting. Since that assertion is performed outside the consumer, the test will fail in case the expected messages doesn't match the consumed ones.
*  Extract RabbitMQ connection instantiation to `RabbitMqChannelFactory` in order to share the same connection between all the different services (`RabbitMqMessagePublisher`, `RabbitMqMessageConsumer` and `RabbitMqMessagePurger`)