### PR TITLE
Refactor unit tests structure

### DIFF
--- a/src/test/tv/codely/scala_http_api/module/UnitTestCase.scala
+++ b/src/test/tv/codely/scala_http_api/module/UnitTestCase.scala
@@ -1,7 +1,6 @@
 package tv.codely.scala_http_api.module
 
-import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 
-protected[module] trait UnitTestCase extends WordSpec with Matchers with ScalaFutures with MockFactory
+protected[module] trait UnitTestCase extends WordSpec with Matchers with ScalaFutures

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/MessagePublisherMock.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/MessagePublisherMock.scala
@@ -1,9 +1,12 @@
 package tv.codely.scala_http_api.module.shared.infrastructure
 
 import org.scalamock.scalatest.MockFactory
+import tv.codely.scala_http_api.module.UnitTestCase
 import tv.codely.scala_http_api.module.shared.domain.{Message, MessagePublisher}
 
 protected[module] trait MessagePublisherMock extends MockFactory {
+  this: UnitTestCase => // Make mandatory to also extend UnitTestCase in order to avoid using mocks in any other kind of test.
+
   protected val messagePublisher: MessagePublisher = mock[MessagePublisher]
 
   protected def publisherShouldPublish(message: Message): Unit =

--- a/src/test/tv/codely/scala_http_api/module/user/application/register/UserRegistererShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/user/application/register/UserRegistererShould.scala
@@ -1,10 +1,11 @@
 package tv.codely.scala_http_api.module.user.application.register
 
+import tv.codely.scala_http_api.module.UnitTestCase
 import tv.codely.scala_http_api.module.shared.infrastructure.MessagePublisherMock
-import tv.codely.scala_http_api.module.user.UserUnitTestCase
 import tv.codely.scala_http_api.module.user.domain.{UserRegisteredStub, UserStub}
+import tv.codely.scala_http_api.module.user.infrastructure.repository.UserRepositoryMock
 
-final class UserRegistererShould extends UserUnitTestCase with MessagePublisherMock {
+final class UserRegistererShould extends UnitTestCase with UserRepositoryMock with MessagePublisherMock {
   private val registerer = new UserRegisterer(repository, messagePublisher)
 
   "register a user" in {

--- a/src/test/tv/codely/scala_http_api/module/user/application/search/UsersSearcherShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/user/application/search/UsersSearcherShould.scala
@@ -1,9 +1,10 @@
 package tv.codely.scala_http_api.module.user.application.search
 
-import tv.codely.scala_http_api.module.user.UserUnitTestCase
+import tv.codely.scala_http_api.module.UnitTestCase
 import tv.codely.scala_http_api.module.user.domain.UserStub
+import tv.codely.scala_http_api.module.user.infrastructure.repository.UserRepositoryMock
 
-final class UsersSearcherShould extends UserUnitTestCase {
+final class UsersSearcherShould extends UnitTestCase with UserRepositoryMock {
   private val searcher = new UsersSearcher(repository)
 
   "search all existing users" in {

--- a/src/test/tv/codely/scala_http_api/module/user/infrastructure/repository/UserRepositoryMock.scala
+++ b/src/test/tv/codely/scala_http_api/module/user/infrastructure/repository/UserRepositoryMock.scala
@@ -1,13 +1,14 @@
-package tv.codely.scala_http_api.module.user
+package tv.codely.scala_http_api.module.user.infrastructure.repository
 
+import org.scalamock.scalatest.MockFactory
 import tv.codely.scala_http_api.module.UnitTestCase
 import tv.codely.scala_http_api.module.user.domain.{User, UserRepository}
 
 import scala.concurrent.Future
 
-protected[user] trait UserUnitTestCase extends UnitTestCase {
-  // @ToDo: Use multiple inheritance in test suites extending from UnitTestCase and this UserUnitTestCase
-  // in order to make more explicit what we have and avoid making the UnitTestCase extending from MockFactory
+protected[user] trait UserRepositoryMock extends MockFactory {
+  this: UnitTestCase => // Make mandatory to also extend UnitTestCase in order to avoid using mocks in any other kind of test.
+
   protected val repository: UserRepository = mock[UserRepository]
 
   protected def repositoryShouldSave(user: User): Unit =

--- a/src/test/tv/codely/scala_http_api/module/video/application/create/VideoCreatorShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/video/application/create/VideoCreatorShould.scala
@@ -1,10 +1,11 @@
 package tv.codely.scala_http_api.module.video.application.create
 
+import tv.codely.scala_http_api.module.UnitTestCase
 import tv.codely.scala_http_api.module.shared.infrastructure.MessagePublisherMock
-import tv.codely.scala_http_api.module.video.VideoUnitTestCase
 import tv.codely.scala_http_api.module.video.domain.{VideoCreatedStub, VideoStub}
+import tv.codely.scala_http_api.module.video.infrastructure.repository.VideoRepositoryMock
 
-final class VideoCreatorShould extends VideoUnitTestCase with MessagePublisherMock {
+final class VideoCreatorShould extends UnitTestCase with VideoRepositoryMock with MessagePublisherMock {
   private val creator = new VideoCreator(repository, messagePublisher)
 
   "save a video" in {

--- a/src/test/tv/codely/scala_http_api/module/video/application/search/VideosSearcherShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/video/application/search/VideosSearcherShould.scala
@@ -1,9 +1,10 @@
 package tv.codely.scala_http_api.module.video.application.search
 
-import tv.codely.scala_http_api.module.video.VideoUnitTestCase
+import tv.codely.scala_http_api.module.UnitTestCase
 import tv.codely.scala_http_api.module.video.domain.VideoStub
+import tv.codely.scala_http_api.module.video.infrastructure.repository.VideoRepositoryMock
 
-final class VideosSearcherShould extends VideoUnitTestCase {
+final class VideosSearcherShould extends UnitTestCase with VideoRepositoryMock {
   private val searcher = new VideosSearcher(repository)
 
   "search all existing videos" in {

--- a/src/test/tv/codely/scala_http_api/module/video/infrastructure/repository/VideoRepositoryMock.scala
+++ b/src/test/tv/codely/scala_http_api/module/video/infrastructure/repository/VideoRepositoryMock.scala
@@ -1,13 +1,14 @@
-package tv.codely.scala_http_api.module.video
+package tv.codely.scala_http_api.module.video.infrastructure.repository
 
+import org.scalamock.scalatest.MockFactory
 import tv.codely.scala_http_api.module.UnitTestCase
 import tv.codely.scala_http_api.module.video.domain.{Video, VideoRepository}
 
 import scala.concurrent.Future
 
-protected[video] trait VideoUnitTestCase extends UnitTestCase {
-  // @ToDo: Use multiple inheritance in test suites extending from UnitTestCase and this VideoUnitTestCase
-  // in order to make more explicit what we have and avoid making the UnitTestCase extending from MockFactory
+protected[video] trait VideoRepositoryMock extends MockFactory {
+  this: UnitTestCase => // Make mandatory to also extend UnitTestCase in order to avoid using mocks in any other kind of test.
+
   protected val repository: VideoRepository = mock[VideoRepository]
 
   protected def repositoryShouldSave(video: Video): Unit =


### PR DESCRIPTION
⚠️ Dependent PR: #6, #7, #8, #9, #10 & #11 ⚠️

* Replace the unified `VideoUnitTestCase` & `UserUnitTestCase` for multiple inheritance from isolated traits for each mock. Why:
  * Explicitness: Since our final unit tests would have to extend from each one of the used traits, we could see where do the mocks come from.
  * Decoupling/SRP/maintainability: This way each mock has its very own trait making it easier to add more behavior without ending up with a method explosion in the corresponding module `XxxUnitTestCase` due to using multiple dependencies in that module
* Remove `MockFactory` inheritance form `UnitTestCase` since it no longer needs it
