### PR TITLE
09.1 Add logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,9 @@ lib_managed/
 src_managed/
 project/plugins/project/
 
-# Ignore the environment variables file intended for customize the Docker containers parameters letting each developer has its own values.
+# Environment variables file intended for customize the Docker containers parameters letting each developer has its own values.
 docker/.env
+
+# Application log file and compressed previous logs (see conf/logback.xml)
+var/log/app_log.json
+var/log/app_log-*.gz

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,8 +1,14 @@
 style = default
 
-align = true
-
 maxColumn = 120
+
+continuationIndent.callSite = 2
+
+align = more
+
+runner.optimizer.forceConfigStyleMinArgCount = 1
+
+rewrite.rules = [SortImports]
 
 importSelectors = singleLine
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - cp .env.dist .env
   - docker-compose up -d
   - cd ..
+  - mkdir /var/log/codelytv_scala_api/
   - sbt createDbTables
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
   - cp .env.dist .env
   - docker-compose up -d
   - cd ..
-  - mkdir /var/log/codelytv_scala_api/
   - sbt createDbTables
 
 script:

--- a/README.md
+++ b/README.md
@@ -44,14 +44,13 @@ If you want to install this hook, just `cd doc/hooks` and run `./install-hooks.s
 
 ## Logs
 
-We've added a logging mechanism thanks to [logback](https://github.com/qos-ch/logback) and [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder/) in order to output the log records through the standard output channel (usually, your terminal :P), and also store them in a log file.
+We've added a logging mechanism thanks to [logback](https://github.com/qos-ch/logback) and [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder/) in order to:
+* Output the log records through the standard output channel (usually, your terminal :P)
+* Store the log records in JSON format in a log file available at `var/log/app_log.json`
+* Compress the historical log files into `var/log/app_log-%d{yyyy-MM-dd}.gz` files
+* Delete compressed historical logs older than 10 days 
 
-This log file will be available at `/var/log/codelytv_scala_api/app_log.json` but firstly, you'll need to create this directory with proper permissions 🙂
-
-`sudo mkdir /var/log/codelytv_scala_api/`
-`sudo chown $(whoami):$(id -gn) /var/log/codelytv_scala_api/`
-
-We've added a rolling policy in order to only keep the last 10 days of logs. If you want more information on the logging policies and appenders, [take a look at the logback.xml](conf/logback.xml).  
+If you want more information on the logging policies and appenders, [take a look at the logback.xml](conf/logback.xml).  
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ You can define what this task does modifying the `prep` task in the `build.sbt` 
  
 If you want to install this hook, just `cd doc/hooks` and run `./install-hooks.sh`.
 
+## Logs
+
+We've added a logging mechanism thanks to [logback](https://github.com/qos-ch/logback) and [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder/) in order to output the log records through the standard output channel (usually, your terminal :P), and also store them in a log file.
+
+This log file will be available at `/var/log/codelytv_scala_api/app_log.json` but firstly, you'll need to create this directory with proper permissions 🙂
+
+`sudo mkdir /var/log/codelytv_scala_api/`
+`sudo chown $(whoami):$(id -gn) /var/log/codelytv_scala_api/`
+
+We've added a rolling policy in order to only keep the last 10 days of logs. If you want more information on the logging policies and appenders, [take a look at the logback.xml](conf/logback.xml).  
+
 ## About
 
 This hopefully helpful utility has been developed by [CodelyTV](https://github.com/CodelyTV) and [contributors](https://github.com/CodelyTV/scala-http-api/graphs/contributors).

--- a/build.sbt
+++ b/build.sbt
@@ -14,11 +14,13 @@ addCommandAlias("tsf", "testShowFailed")
 addCommandAlias("c", "compile")
 addCommandAlias("tc", "test:compile")
 
-addCommandAlias("f", "scalafmt")       // Format all files according to ScalaFmt
-addCommandAlias("fc", "scalafmtCheck") // Check if all files are formatted according to ScalaFmt
+addCommandAlias("f", "scalafmt")             // Format production files according to ScalaFmt
+addCommandAlias("fc", "scalafmtCheck")       // Check if production files are formatted according to ScalaFmt
+addCommandAlias("tf", "test:scalafmt")       // Format test files according to ScalaFmt
+addCommandAlias("tfc", "test:scalafmtCheck") // Check if test files are formatted according to ScalaFmt
 
-// All the needed tasks before pushing to the repository (compile, compile test & format check)
-addCommandAlias("prep", ";c;tc;fc")
+// All the needed tasks before pushing to the repository (compile, compile test, format check in prod and test)
+addCommandAlias("prep", ";c;tc;fc;tfc")
 
 TaskKey[Unit]("createDbTables") := (runMain in Compile)
   .toTask(" tv.codely.scala_http_api.entry_point.cli.DbTablesCreator")

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -9,9 +9,9 @@
     </appender>
 
     <appender name="jsonFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/var/log/codelytv_scala_api/app_log.json</file>
+        <file>var/log/app_log.json</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/var/log/codelytv_scala_api/app_log-%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>var/log/app_log-%d{yyyy-MM-dd}.gz</fileNamePattern>
             <maxHistory>10</maxHistory>
         </rollingPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -3,7 +3,7 @@
     <appender name="stdOut" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>
-                %highlight([%level]) [%date{HH:mm:ss.SSS}] [%class{0}#%method:%line] %message%n
+                %highlight([%level]) [%date{HH:mm:ss.SSS}] [%class{0}#%method:%line] %message \(%mdc\)%n
             </pattern>
         </encoder>
     </appender>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -3,7 +3,7 @@
     <appender name="stdOut" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>
-                %highlight([%level]) [%date{HH:mm:ss.SSS}] [%class{0}#%method:%line] %message \(%mdc\)%n
+                %highlight([%level]) [%date{HH:mm:ss.SSS}] [%class{0}#%method:%line] %message \(%mdc\) %n%throwable
             </pattern>
         </encoder>
     </appender>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="stdOut" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>
+                %highlight([%level]) [%date{HH:mm:ss.SSS}] [%class{0}#%method:%line] %message%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <appender name="jsonFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/var/log/codelytv_scala_api/app_log.json</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/var/log/codelytv_scala_api/app_log-%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <maxHistory>10</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <logger name="ch.qos.logback" level="WARN"/>
+
+    <root level="all">
+        <appender-ref ref="stdOut"/>
+        <appender-ref ref="jsonFile"/>
+    </root>
+</configuration>

--- a/project/Configuration.scala
+++ b/project/Configuration.scala
@@ -10,18 +10,58 @@ object Configuration {
     scalaSource in Compile := baseDirectory.value / "/src/main",
     scalaSource in Test := baseDirectory.value / "/src/test",
     resourceDirectory in Compile := baseDirectory.value / "conf",
-    // Compiler options
+    // Compiler options. More information: https://tpolecat.github.io/2017/04/25/scalac-flags.html
     scalacOptions ++= Seq(
-      "-deprecation", // Warnings deprecation
-      "-feature", // Advise features
-      "-unchecked", // More warnings. Strict
-      "-Xlint", // More warnings when compiling
-      "-Ywarn-dead-code",
-      "-Ywarn-unused",
-      "-Ywarn-unused-import",
-      "-Xcheckinit" // Check against early initialization
+      "-deprecation", // Emit warning and location for usages of deprecated APIs.
+      "-encoding",
+      "utf-8", // Specify character encoding used by source files.
+      "-explaintypes", // Explain type errors in more detail.
+      "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+      "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+      "-language:experimental.macros", // Allow macro definition (besides implementation and application)
+      "-language:higherKinds", // Allow higher-kinded types
+      "-language:implicitConversions", // Allow definition of implicit functions called views
+      "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+      "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
+      "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+      "-Xfuture", // Turn on future language features.
+      "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+      "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+      "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+      "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+      "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+      "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+      "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
+      "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+      "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
+      "-Xlint:option-implicit", // Option.apply used implicit view.
+      "-Xlint:package-object-classes", // Class or object defined in package object.
+      "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+      "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+      "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+      "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+      "-Xlint:unsound-match", // Pattern match may not be typesafe.
+      "-Yno-adapted-args", // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+      "-Ypartial-unification", // Enable partial unification in type constructor inference
+      "-Ywarn-dead-code", // Warn when dead code is identified.
+      "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+      "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+      "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`.
+      "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Ywarn-nullary-unit", // Warn when nullary methods return Unit.
+      "-Ywarn-numeric-widen", // Warn when numerics are widened.
+      "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+      "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+      "-Ywarn-unused:locals", // Warn if a local definition is unused.
+      "-Ywarn-unused:params", // Warn if a value parameter is unused.
+      "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
+      "-Ywarn-unused:privates", // Warn if a private member is unused.
+      "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
     ),
-    scalacOptions in run in Compile -= "-Xcheckinit", // Remove it in production because it's expensive
+    scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"), // Leave the console REPL usable :P
+    scalacOptions in (Compile, run) -= "-Xcheckinit", // Expensive to run in prod
+    scalacOptions in (Test, compile) --= Seq("-Xfatal-warnings"), // Due to deprecated ETA expansion used with ScalaMock
     javaOptions += "-Duser.timezone=UTC",
     // Test options
     parallelExecution in Test := false,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,16 +7,18 @@ object Dependencies {
   }
 
   val production = Seq(
-    "com.github.nscala-time" %% "nscala-time"          % "2.18.0",
-    "com.lihaoyi"            %% "pprint"               % "0.5.3",
-    "com.typesafe.akka"      %% "akka-http"            % Versions.akkaHttp,
-    "com.typesafe.akka"      %% "akka-actor"           % Versions.akka,
-    "com.typesafe.akka"      %% "akka-stream"          % Versions.akka, // Explicit dependency due to: https://bit.ly/akka-http-25
-    "com.typesafe.akka"      %% "akka-http-spray-json" % Versions.akkaHttp,
-    "org.tpolecat"           %% "doobie-core"          % "0.5.0-M13",
-    "mysql"                  % "mysql-connector-java"  % "5.1.45",
-    "com.github.scopt"       %% "scopt"                % "3.7.0", // Command Line Commands such as de DbTablesCreator
-    "com.newmotion"          %% "akka-rabbitmq"        % "5.0.0"
+    "com.github.nscala-time"     %% "nscala-time"          % "2.18.0",
+    "com.lihaoyi"                %% "pprint"               % "0.5.3",
+    "com.typesafe.akka"          %% "akka-http"            % Versions.akkaHttp,
+    "com.typesafe.akka"          %% "akka-actor"           % Versions.akka,
+    "com.typesafe.akka"          %% "akka-stream"          % Versions.akka, // Explicit dependency due to: https://bit.ly/akka-http-25
+    "com.typesafe.akka"          %% "akka-http-spray-json" % Versions.akkaHttp,
+    "org.tpolecat"               %% "doobie-core"          % "0.5.0-M13",
+    "mysql"                      % "mysql-connector-java"  % "5.1.45",
+    "com.github.scopt"           %% "scopt"                % "3.7.0", // Command Line Commands such as de DbTablesCreator
+    "com.newmotion"              %% "akka-rabbitmq"        % "5.0.0",
+    "ch.qos.logback"             % "logback-classic"       % "1.2.3", // Logging backend implementation
+    "com.typesafe.scala-logging" %% "scala-logging"        % "3.7.2" // SLF4J Scala wrapper
   )
 
   val test = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,18 +7,19 @@ object Dependencies {
   }
 
   val production = Seq(
-    "com.github.nscala-time"     %% "nscala-time"          % "2.18.0",
-    "com.lihaoyi"                %% "pprint"               % "0.5.3",
-    "com.typesafe.akka"          %% "akka-http"            % Versions.akkaHttp,
-    "com.typesafe.akka"          %% "akka-actor"           % Versions.akka,
-    "com.typesafe.akka"          %% "akka-stream"          % Versions.akka, // Explicit dependency due to: https://bit.ly/akka-http-25
-    "com.typesafe.akka"          %% "akka-http-spray-json" % Versions.akkaHttp,
-    "org.tpolecat"               %% "doobie-core"          % "0.5.0-M13",
-    "mysql"                      % "mysql-connector-java"  % "5.1.45",
-    "com.github.scopt"           %% "scopt"                % "3.7.0", // Command Line Commands such as de DbTablesCreator
-    "com.newmotion"              %% "akka-rabbitmq"        % "5.0.0",
-    "ch.qos.logback"             % "logback-classic"       % "1.2.3", // Logging backend implementation
-    "com.typesafe.scala-logging" %% "scala-logging"        % "3.7.2" // SLF4J Scala wrapper
+    "com.github.nscala-time"     %% "nscala-time"             % "2.18.0",
+    "com.lihaoyi"                %% "pprint"                  % "0.5.3",
+    "com.typesafe.akka"          %% "akka-http"               % Versions.akkaHttp,
+    "com.typesafe.akka"          %% "akka-actor"              % Versions.akka,
+    "com.typesafe.akka"          %% "akka-stream"             % Versions.akka, // Explicit dependency due to: https://bit.ly/akka-http-25
+    "com.typesafe.akka"          %% "akka-http-spray-json"    % Versions.akkaHttp,
+    "org.tpolecat"               %% "doobie-core"             % "0.5.0-M13",
+    "mysql"                      % "mysql-connector-java"     % "5.1.45",
+    "com.github.scopt"           %% "scopt"                   % "3.7.0", // Command Line Commands such as de DbTablesCreator
+    "com.newmotion"              %% "akka-rabbitmq"           % "5.0.0",
+    "ch.qos.logback"             % "logback-classic"          % "1.2.3", // Logging backend implementation
+    "com.typesafe.scala-logging" %% "scala-logging"           % "3.7.2", // SLF4J Scala wrapper
+    "net.logstash.logback"       % "logstash-logback-encoder" % "4.11" // Log JSON encoder
   )
 
   val test = Seq(

--- a/src/main/tv/codely/scala_http_api/module/shared/domain/Logger.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/domain/Logger.scala
@@ -4,4 +4,8 @@ trait Logger {
   def info(message: String)
   def warn(message: String)
   def error(message: String)
+
+  def info(message: String, context: Map[String, Any]): Unit
+  def warn(message: String, context: Map[String, Any]): Unit
+  def error(message: String, context: Map[String, Any]): Unit
 }

--- a/src/main/tv/codely/scala_http_api/module/shared/domain/Logger.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/domain/Logger.scala
@@ -1,11 +1,15 @@
 package tv.codely.scala_http_api.module.shared.domain
 
 trait Logger {
-  def info(message: String): Unit
-  def warn(message: String): Unit
-  def error(message: String): Unit
+  def info(message: String, context: Map[String, Any] = Map.empty): Unit
+  def warn(message: String, context: Map[String, Any] = Map.empty): Unit
+  def error(message: String, context: Map[String, Any] = Map.empty): Unit
 
-  def info(message: String, context: Map[String, Any]): Unit
-  def warn(message: String, context: Map[String, Any]): Unit
-  def error(message: String, context: Map[String, Any]): Unit
+  def info(message: String, cause: Throwable): Unit
+  def warn(message: String, cause: Throwable): Unit
+  def error(message: String, cause: Throwable): Unit
+
+  def info(message: String, cause: Throwable, context: Map[String, Any]): Unit
+  def warn(message: String, cause: Throwable, context: Map[String, Any]): Unit
+  def error(message: String, cause: Throwable, context: Map[String, Any]): Unit
 }

--- a/src/main/tv/codely/scala_http_api/module/shared/domain/Logger.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/domain/Logger.scala
@@ -1,9 +1,9 @@
 package tv.codely.scala_http_api.module.shared.domain
 
 trait Logger {
-  def info(message: String)
-  def warn(message: String)
-  def error(message: String)
+  def info(message: String): Unit
+  def warn(message: String): Unit
+  def error(message: String): Unit
 
   def info(message: String, context: Map[String, Any]): Unit
   def warn(message: String, context: Map[String, Any]): Unit

--- a/src/main/tv/codely/scala_http_api/module/shared/domain/Logger.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/domain/Logger.scala
@@ -1,0 +1,7 @@
+package tv.codely.scala_http_api.module.shared.domain
+
+trait Logger {
+  def info(message: String)
+  def warn(message: String)
+  def error(message: String)
+}

--- a/src/main/tv/codely/scala_http_api/module/shared/infrastructure/dependency_injection/SharedModuleDependencyContainer.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/infrastructure/dependency_injection/SharedModuleDependencyContainer.scala
@@ -2,8 +2,9 @@ package tv.codely.scala_http_api.module.shared.infrastructure.dependency_injecti
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import tv.codely.scala_http_api.module.shared.domain.MessagePublisher
+import tv.codely.scala_http_api.module.shared.domain.{Logger, MessagePublisher}
 import tv.codely.scala_http_api.module.shared.infrastructure.config.{DbConfig, MessageBrokerConfig}
+import tv.codely.scala_http_api.module.shared.infrastructure.logger.scala_logging.ScalaLoggingLogger
 import tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq.{RabbitMqChannelFactory, RabbitMqMessagePublisher}
 import tv.codely.scala_http_api.module.shared.infrastructure.persistence.doobie.DoobieDbConnection
 
@@ -22,4 +23,6 @@ final class SharedModuleDependencyContainer(
 
   private val rabbitMqChannelFactory     = new RabbitMqChannelFactory(publisherConfig)
   val messagePublisher: MessagePublisher = new RabbitMqMessagePublisher(rabbitMqChannelFactory)
+
+  val logger: Logger = new ScalaLoggingLogger
 }

--- a/src/main/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLogger.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLogger.scala
@@ -7,20 +7,29 @@ import tv.codely.scala_http_api.module.shared.domain.Logger
 final class ScalaLoggingLogger extends Logger {
   private val logger = ScalaLogging(name = "codelytv_scala_api")
 
-  override def info(message: String): Unit = logger.info(message)
-
-  override def warn(message: String): Unit = logger.warn(message)
-
-  override def error(message: String): Unit = logger.error(message)
-
-  override def info(message: String, context: Map[String, Any]): Unit =
+  override def info(message: String, context: Map[String, Any] = Map.empty): Unit =
     addContextParameters(context, log = logger.info(message))
 
-  override def warn(message: String, context: Map[String, Any]): Unit =
+  override def warn(message: String, context: Map[String, Any] = Map.empty): Unit =
     addContextParameters(context, log = logger.warn(message))
 
-  override def error(message: String, context: Map[String, Any]): Unit =
+  override def error(message: String, context: Map[String, Any] = Map.empty): Unit =
     addContextParameters(context, log = logger.error(message))
+
+  override def info(message: String, cause: Throwable): Unit = logger.info(message, cause)
+
+  override def warn(message: String, cause: Throwable): Unit = logger.warn(message, cause)
+
+  override def error(message: String, cause: Throwable): Unit = logger.error(message, cause)
+
+  override def info(message: String, cause: Throwable, context: Map[String, Any]): Unit =
+    addContextParameters(context, log = logger.info(message, cause))
+
+  override def warn(message: String, cause: Throwable, context: Map[String, Any]): Unit =
+    addContextParameters(context, log = logger.warn(message, cause))
+
+  override def error(message: String, cause: Throwable, context: Map[String, Any]): Unit =
+    addContextParameters(context, log = logger.error(message, cause))
 
   private def addContextParameters(context: Map[String, Any], log: => Unit): Unit = {
     context.foreach { case (key: String, value: Any) => MDC.put(key, value.toString) }

--- a/src/main/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLogger.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLogger.scala
@@ -1,0 +1,14 @@
+package tv.codely.scala_http_api.module.shared.infrastructure.logger.scala_logging
+
+import com.typesafe.scalalogging.Logger
+import tv.codely.scala_http_api.module.shared.domain.{Logger => LoggerContract}
+
+final class ScalaLoggingLogger extends LoggerContract {
+  private val logger = Logger(name = "codelytv_scala_api")
+
+  override def info(message: String): Unit = logger.info(message)
+
+  override def warn(message: String): Unit = logger.warn(message)
+
+  override def error(message: String): Unit = logger.error(message)
+}

--- a/src/main/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLogger.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLogger.scala
@@ -1,6 +1,7 @@
 package tv.codely.scala_http_api.module.shared.infrastructure.logger.scala_logging
 
 import com.typesafe.scalalogging.{Logger => ScalaLogging}
+import org.slf4j.MDC
 import tv.codely.scala_http_api.module.shared.domain.Logger
 
 final class ScalaLoggingLogger extends Logger {
@@ -11,4 +12,19 @@ final class ScalaLoggingLogger extends Logger {
   override def warn(message: String): Unit = logger.warn(message)
 
   override def error(message: String): Unit = logger.error(message)
+
+  override def info(message: String, context: Map[String, Any]): Unit =
+    addContextParameters(context, log = logger.info(message))
+
+  override def warn(message: String, context: Map[String, Any]): Unit =
+    addContextParameters(context, log = logger.warn(message))
+
+  override def error(message: String, context: Map[String, Any]): Unit =
+    addContextParameters(context, log = logger.error(message))
+
+  private def addContextParameters(context: Map[String, Any], log: => Unit): Unit = {
+    context.foreach { case (key: String, value: Any) => MDC.put(key, value.toString) }
+    log
+    MDC.clear()
+  }
 }

--- a/src/main/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLogger.scala
+++ b/src/main/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLogger.scala
@@ -1,10 +1,10 @@
 package tv.codely.scala_http_api.module.shared.infrastructure.logger.scala_logging
 
-import com.typesafe.scalalogging.Logger
-import tv.codely.scala_http_api.module.shared.domain.{Logger => LoggerContract}
+import com.typesafe.scalalogging.{Logger => ScalaLogging}
+import tv.codely.scala_http_api.module.shared.domain.Logger
 
-final class ScalaLoggingLogger extends LoggerContract {
-  private val logger = Logger(name = "codelytv_scala_api")
+final class ScalaLoggingLogger extends Logger {
+  private val logger = ScalaLogging(name = "codelytv_scala_api")
 
   override def info(message: String): Unit = logger.info(message)
 

--- a/src/test/tv/codely/scala_http_api/module/IntegrationTestCase.scala
+++ b/src/test/tv/codely/scala_http_api/module/IntegrationTestCase.scala
@@ -1,7 +1,7 @@
 package tv.codely.scala_http_api.module
 
 import com.typesafe.config.ConfigFactory
-import tv.codely.scala_http_api.module.shared.domain.MessagePublisher
+import tv.codely.scala_http_api.module.shared.domain.{Logger, MessagePublisher}
 import tv.codely.scala_http_api.module.shared.infrastructure.config.{DbConfig, MessageBrokerConfig}
 import tv.codely.scala_http_api.module.shared.infrastructure.dependency_injection.SharedModuleDependencyContainer
 import tv.codely.scala_http_api.module.shared.infrastructure.message_broker.rabbitmq.RabbitMqChannelFactory
@@ -23,4 +23,5 @@ protected[scala_http_api] trait IntegrationTestCase extends UnitTestCase {
   protected val doobieDbConnection: DoobieDbConnection         = sharedDependencies.doobieDbConnection
   protected val rabbitMqChannelFactory: RabbitMqChannelFactory = new RabbitMqChannelFactory(publisherConfig)
   protected val messagePublisher: MessagePublisher             = sharedDependencies.messagePublisher
+  protected val logger: Logger                                 = sharedDependencies.logger
 }

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
@@ -13,10 +13,40 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
   "log info messages in the app log file in a JSON format" in {
     cleanAppLogFileContents()
 
-    val logText = "This is a dummy message to log from the integration test"
+    val message = "This is a dummy info message from the integration test"
 
-    logger.info(logText)
+    logger.info(message)
 
+    appLogFileShouldContain(message, level = "INFO", levelValue = 20000)
+  }
+
+  "log warn messages in the app log file in a JSON format" in {
+    cleanAppLogFileContents()
+
+    val message = "This is a dummy warn message from the integration test"
+
+    logger.warn(message)
+
+    appLogFileShouldContain(message, level = "WARN", levelValue = 30000)
+  }
+
+  "log error messages in the app log file in a JSON format" in {
+    cleanAppLogFileContents()
+
+    val message = "This is a dummy error message from the integration test"
+
+    logger.error(message)
+
+    appLogFileShouldContain(message, level = "ERROR", levelValue = 40000)
+  }
+
+  private def cleanAppLogFileContents(): Unit = {
+    val appLogFileWriter = new PrintWriter(new File(appLogFilePath), "UTF-8")
+    appLogFileWriter.write("")
+    appLogFileWriter.close()
+  }
+
+  private def appLogFileShouldContain(message: String, level: String, levelValue: Int): Unit = {
     val fileContents = Source.fromFile(appLogFilePath).getLines.mkString
 
     val currentThreadName = Thread.currentThread().getName
@@ -24,11 +54,11 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
     val expectedLog = Map(
       "@timestamp"  -> JsString("We'll not be able to compare this value"),
       "@version"    -> JsNumber(1),
-      "message"     -> JsString(logText),
+      "message"     -> JsString(message),
       "logger_name" -> JsString("codelytv_scala_api"),
       "thread_name" -> JsString(currentThreadName),
-      "level"       -> JsString("INFO"),
-      "level_value" -> JsNumber(20000)
+      "level"       -> JsString(level),
+      "level_value" -> JsNumber(levelValue)
     )
 
     val actualLog = fileContents.parseJson.asJsObject.fields
@@ -36,16 +66,5 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
     actualLog.keys shouldBe expectedLog.keys
 
     (actualLog - "@timestamp") shouldBe (expectedLog - "@timestamp")
-  }
-
-  "log warn messages in the app log file in a JSON format" in pending
-  "log error messages in the app log file in a JSON format" in pending
-  "compress historical logs" in pending
-  "delete historical logs older than 10 days ago" in pending
-
-  private def cleanAppLogFileContents(): Unit = {
-    val appLogFileWriter = new PrintWriter(new File(appLogFilePath), "UTF-8")
-    appLogFileWriter.write("")
-    appLogFileWriter.close()
   }
 }

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
@@ -17,7 +17,7 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     logger.info(message)
 
-    appLogFileShouldContain(message, level = "INFO", levelValue = 20000)
+    appLogFileShouldContainRecord(message, level = "INFO", levelValue = 20000)
   }
 
   "log warn messages in the app log file in a JSON format" in {
@@ -27,7 +27,7 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     logger.warn(message)
 
-    appLogFileShouldContain(message, level = "WARN", levelValue = 30000)
+    appLogFileShouldContainRecord(message, level = "WARN", levelValue = 30000)
   }
 
   "log error messages in the app log file in a JSON format" in {
@@ -37,7 +37,43 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     logger.error(message)
 
-    appLogFileShouldContain(message, level = "ERROR", levelValue = 40000)
+    appLogFileShouldContainRecord(message, level = "ERROR", levelValue = 40000)
+  }
+
+  "log info messages including context parameters" in {
+    cleanAppLogFileContents()
+
+    val message = "This is a dummy info message with context parameters from the integration test"
+
+    val context = Map("some_context_parameter" -> "some_value")
+
+    logger.info(message, context)
+
+    appLogFileShouldContainRecordWithKeys(message, level = "INFO", levelValue = 20000, context)
+  }
+
+  "log warn messages including context parameters" in {
+    cleanAppLogFileContents()
+
+    val message = "This is a dummy warn message with context parameters from the integration test"
+
+    val context = Map("some_context_parameter" -> "some_value")
+
+    logger.warn(message, context)
+
+    appLogFileShouldContainRecordWithKeys(message, level = "WARN", levelValue = 30000, context)
+  }
+
+  "log error messages including context parameters" in {
+    cleanAppLogFileContents()
+
+    val message = "This is a dummy error message with context parameters from the integration test"
+
+    val context = Map("some_context_parameter" -> "some_value")
+
+    logger.error(message, context)
+
+    appLogFileShouldContainRecordWithKeys(message, level = "ERROR", levelValue = 40000, context)
   }
 
   private def cleanAppLogFileContents(): Unit = {
@@ -46,7 +82,11 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
     appLogFileWriter.close()
   }
 
-  private def appLogFileShouldContain(message: String, level: String, levelValue: Int): Unit = {
+  private def appLogFileShouldContainRecord(
+      message: String,
+      level: String,
+      levelValue: Int
+  ): Unit = {
     val fileContents = Source.fromFile(appLogFilePath).getLines.mkString
 
     val currentThreadName = Thread.currentThread().getName
@@ -64,7 +104,37 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
     val actualLog = fileContents.parseJson.asJsObject.fields
 
     actualLog.keys shouldBe expectedLog.keys
-
     (actualLog - "@timestamp") shouldBe (expectedLog - "@timestamp")
+  }
+
+  /** We're only testing for the log record keys because for some strange reason if we perform the assertion:
+    * (actualLog - "@timestamp") shouldBe (expectedLog - "@timestamp")
+    * the test fails as if the two log records were different.
+    * The most strange thing is that if we copy the expected and actual results form the ScalaTest exception,
+    * they're exactly the same expression :/
+    */
+  private def appLogFileShouldContainRecordWithKeys(
+      message: String,
+      level: String,
+      levelValue: Int,
+      context: Map[String, Any]
+  ): Unit = {
+    val fileContents = Source.fromFile(appLogFilePath).getLines.mkString
+
+    val currentThreadName = Thread.currentThread().getName
+
+    val expectedLog = Map(
+      "@timestamp"  -> JsString("We'll not be able to compare this value"),
+      "@version"    -> JsNumber(1),
+      "message"     -> JsString(message),
+      "logger_name" -> JsString("codelytv_scala_api"),
+      "thread_name" -> JsString(currentThreadName),
+      "level"       -> JsString(level),
+      "level_value" -> JsNumber(levelValue)
+    ) ++ context
+
+    val actualLog = fileContents.parseJson.asJsObject.fields
+
+    actualLog.keys shouldBe expectedLog.keys
   }
 }

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
@@ -17,7 +17,7 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     logger.info(message)
 
-    appLogFileShouldContainRecord(message, level = "INFO", levelValue = 20000)
+    appLogFileShouldContain(message, level = "INFO", levelValue = 20000)
   }
 
   "log warn messages in the app log file in a JSON format" in {
@@ -27,7 +27,7 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     logger.warn(message)
 
-    appLogFileShouldContainRecord(message, level = "WARN", levelValue = 30000)
+    appLogFileShouldContain(message, level = "WARN", levelValue = 30000)
   }
 
   "log error messages in the app log file in a JSON format" in {
@@ -37,7 +37,7 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     logger.error(message)
 
-    appLogFileShouldContainRecord(message, level = "ERROR", levelValue = 40000)
+    appLogFileShouldContain(message, level = "ERROR", levelValue = 40000)
   }
 
   "log info messages including context parameters" in {
@@ -45,11 +45,12 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     val message = "This is a dummy info message with context parameters from the integration test"
 
-    val context = Map("some_context_parameter" -> "some_value")
+    val context     = Map("some_context_parameter" -> "some_value")
+    val contextJson = Map("some_context_parameter" -> JsString("some_value"))
 
     logger.info(message, context)
 
-    appLogFileShouldContainRecordWithKeys(message, level = "INFO", levelValue = 20000, context)
+    appLogFileShouldContain(message, level = "INFO", levelValue = 20000, contextJson)
   }
 
   "log warn messages including context parameters" in {
@@ -57,11 +58,12 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     val message = "This is a dummy warn message with context parameters from the integration test"
 
-    val context = Map("some_context_parameter" -> "some_value")
+    val context     = Map("some_context_parameter" -> "some_value")
+    val contextJson = Map("some_context_parameter" -> JsString("some_value"))
 
     logger.warn(message, context)
 
-    appLogFileShouldContainRecordWithKeys(message, level = "WARN", levelValue = 30000, context)
+    appLogFileShouldContain(message, level = "WARN", levelValue = 30000, contextJson)
   }
 
   "log error messages including context parameters" in {
@@ -69,11 +71,12 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     val message = "This is a dummy error message with context parameters from the integration test"
 
-    val context = Map("some_context_parameter" -> "some_value")
+    val context     = Map("some_context_parameter" -> "some_value")
+    val contextJson = Map("some_context_parameter" -> JsString("some_value"))
 
     logger.error(message, context)
 
-    appLogFileShouldContainRecordWithKeys(message, level = "ERROR", levelValue = 40000, context)
+    appLogFileShouldContain(message, level = "ERROR", levelValue = 40000, contextJson)
   }
 
   private def cleanAppLogFileContents(): Unit = {
@@ -82,42 +85,11 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
     appLogFileWriter.close()
   }
 
-  private def appLogFileShouldContainRecord(
-      message: String,
-      level: String,
-      levelValue: Int
-  ): Unit = {
-    val fileContents = Source.fromFile(appLogFilePath).getLines.mkString
-
-    val currentThreadName = Thread.currentThread().getName
-
-    val expectedLog = Map(
-      "@timestamp"  -> JsString("We'll not be able to compare this value"),
-      "@version"    -> JsNumber(1),
-      "message"     -> JsString(message),
-      "logger_name" -> JsString("codelytv_scala_api"),
-      "thread_name" -> JsString(currentThreadName),
-      "level"       -> JsString(level),
-      "level_value" -> JsNumber(levelValue)
-    )
-
-    val actualLog = fileContents.parseJson.asJsObject.fields
-
-    actualLog.keys shouldBe expectedLog.keys
-    (actualLog - "@timestamp") shouldBe (expectedLog - "@timestamp")
-  }
-
-  /** We're only testing for the log record keys because for some strange reason if we perform the assertion:
-    * (actualLog - "@timestamp") shouldBe (expectedLog - "@timestamp")
-    * the test fails as if the two log records were different.
-    * The most strange thing is that if we copy the expected and actual results form the ScalaTest exception,
-    * they're exactly the same expression :/
-    */
-  private def appLogFileShouldContainRecordWithKeys(
+  private def appLogFileShouldContain(
       message: String,
       level: String,
       levelValue: Int,
-      context: Map[String, Any]
+      context: Map[String, JsValue] = Map.empty
   ): Unit = {
     val fileContents = Source.fromFile(appLogFilePath).getLines.mkString
 
@@ -136,5 +108,6 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
     val actualLog = fileContents.parseJson.asJsObject.fields
 
     actualLog.keys shouldBe expectedLog.keys
+    (actualLog - "@timestamp") shouldBe (expectedLog - "@timestamp")
   }
 }

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
@@ -8,12 +8,12 @@ import tv.codely.scala_http_api.module.IntegrationTestCase
 import scala.io.Source
 
 final class ScalaLoggingLoggerShould extends IntegrationTestCase {
-  private val appLogFilePath = "/var/log/codelytv_scala_api/app_log.json"
+  private val appLogFilePath = "var/log/app_log.json"
 
   "log info messages in the app log file in a JSON format" in {
     cleanAppLogFileContents()
 
-    val logText = "This is a dummy message"
+    val logText = "This is a dummy message to log from the integration test"
 
     logger.info(logText)
 
@@ -37,6 +37,11 @@ final class ScalaLoggingLoggerShould extends IntegrationTestCase {
 
     (actualLog - "@timestamp") shouldBe (expectedLog - "@timestamp")
   }
+
+  "log warn messages in the app log file in a JSON format" in pending
+  "log error messages in the app log file in a JSON format" in pending
+  "compress historical logs" in pending
+  "delete historical logs older than 10 days ago" in pending
 
   private def cleanAppLogFileContents(): Unit = {
     val appLogFileWriter = new PrintWriter(new File(appLogFilePath), "UTF-8")

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala
@@ -1,0 +1,46 @@
+package tv.codely.scala_http_api.module.shared.infrastructure.logger.scala_logging
+
+import java.io.{File, PrintWriter}
+
+import spray.json._
+import tv.codely.scala_http_api.module.IntegrationTestCase
+
+import scala.io.Source
+
+final class ScalaLoggingLoggerShould extends IntegrationTestCase {
+  private val appLogFilePath = "/var/log/codelytv_scala_api/app_log.json"
+
+  "log info messages in the app log file in a JSON format" in {
+    cleanAppLogFileContents()
+
+    val logText = "This is a dummy message"
+
+    logger.info(logText)
+
+    val fileContents = Source.fromFile(appLogFilePath).getLines.mkString
+
+    val currentThreadName = Thread.currentThread().getName
+
+    val expectedLog = Map(
+      "@timestamp"  -> JsString("We'll not be able to compare this value"),
+      "@version"    -> JsNumber(1),
+      "message"     -> JsString(logText),
+      "logger_name" -> JsString("codelytv_scala_api"),
+      "thread_name" -> JsString(currentThreadName),
+      "level"       -> JsString("INFO"),
+      "level_value" -> JsNumber(20000)
+    )
+
+    val actualLog = fileContents.parseJson.asJsObject.fields
+
+    actualLog.keys shouldBe expectedLog.keys
+
+    (actualLog - "@timestamp") shouldBe (expectedLog - "@timestamp")
+  }
+
+  private def cleanAppLogFileContents(): Unit = {
+    val appLogFileWriter = new PrintWriter(new File(appLogFilePath), "UTF-8")
+    appLogFileWriter.write("")
+    appLogFileWriter.close()
+  }
+}

--- a/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessageConsumer.scala
+++ b/src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessageConsumer.scala
@@ -14,7 +14,7 @@ final class RabbitMqMessageConsumer(channelFactory: RabbitMqChannelFactory)(queu
           envelope: Envelope,
           properties: BasicProperties,
           body: Array[Byte]
-      ) {
+      ): Unit = {
         val stringBody                 = new String(body)
         val message                    = stringBody.parseJson.convertTo[Message]
         val hasBeenHandledSuccessfully = handler(message)

--- a/src/test/tv/codely/scala_http_api/module/video/infrastructure/marshaller/VideoJsValueMarshaller.scala
+++ b/src/test/tv/codely/scala_http_api/module/video/infrastructure/marshaller/VideoJsValueMarshaller.scala
@@ -13,7 +13,8 @@ object VideoJsValueMarshaller {
             "title"               -> JsString(v.title.value),
             "duration_in_seconds" -> JsNumber(v.duration.value.toSeconds),
             "category"            -> JsString(v.category.toString),
-        ))
+        )
+      )
       .toVector
   )
 }


### PR DESCRIPTION
⚠️ Dependent PR: #6, #7, #8, #9, #10, #11 & #12 ⚠️

# Done

* (Bonus track :P): Include test code style checking in the pre-push hook and update scalafmt rules
* Add `logback-classic` Logging backend for SLF4J and `scala-logging` as a SLF4J wrapper for Scala dependencies
* Configure logging mechanism
  * `stdOut` appender: Prints out in the standard output channel (usually, your terminal :P) the logs with coloured level and basic information such as the timestamp (without the date because it's supposed to serve only as debug information), and the class#method:line which has logged the record
  * `jsonFile` appender: Thanks to the newly added `logstash-logback-encoder` dependency, it encodes the log records as JSON and save them into the `var/log/app_log.json` file
* Add an explanation in the `README.md` regarding the logging mechanism
* Add the `ScalaLoggingLoggerShould` integration test in order to probe that it logs info messages in the app log file in a JSON format
* Add context parameters to the logging mechanism in order to be able to provide isolated values such as the `user_id` which has originated some error in the log, or whatever variable information.
* Add logging methods including the `Throwable` instance that caused the error/warning/info.
  * Didn't defined the `context` with a default value as we did in the case of logging a message without a `Throwable` cause because the compiler doesn't allow it.
  * Didn't defined the `cause` as `Option[Throwable]` or with a default `null` value in order to have cleaner calls while not specifying the cause but with context.