### PR TITLE
Readme instructions + code coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,12 @@ before_install:
   - sbt createDbTables
 
 script:
-  ## Execute the tests
-  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test
+  ## Execute the tests including code coverage. More info: https://github.com/scoverage/sbt-coveralls
+  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M clean coverage test
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+
+after_success:
+  - sbt coverageReport coveralls

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 <img src="http://codely.tv/wp-content/uploads/2016/05/cropped-logo-codelyTV.png" align="left" width="192px" height="192px"/>
 <img align="left" width="0" height="192px" hspace="10"/>
 
-[![Build Status](https://img.shields.io/travis/CodelyTV/scala-http-api/master.svg?style=flat-square)](https://travis-ci.org/CodelyTV/scala-http-api)
 [![License](https://img.shields.io/github/license/CodelyTV/scala-http-api.svg?style=flat-square)](LICENSE)
+[![Build Status](https://img.shields.io/travis/CodelyTV/scala-http-api/master.svg?style=flat-square)](https://travis-ci.org/CodelyTV/scala-http-api)
+[![Coverage Status](https://img.shields.io/coveralls/github/CodelyTV/scala-http-api/master.svg?style=flat-square)](https://coveralls.io/github/CodelyTV/scala-http-api?branch=master)
 
 Project showing up how you could implement a HTTP API with Scala.
  

--- a/README.md
+++ b/README.md
@@ -1,17 +1,59 @@
 # CodelyTV Scala HTTP API
+
+<img src="http://codely.tv/wp-content/uploads/2016/05/cropped-logo-codelyTV.png" align="left" width="192px" height="192px"/>
+<img align="left" width="0" height="192px" hspace="10"/>
+
+[![Build Status](https://img.shields.io/travis/CodelyTV/scala-http-api/master.svg?style=flat-square)](https://travis-ci.org/CodelyTV/scala-http-api)
+[![License](https://img.shields.io/github/license/CodelyTV/scala-http-api.svg?style=flat-square)](LICENSE)
+
+Project showing up how you could implement a HTTP API with Scala.
  
-[![Software License][ico-license]][link-license]
-[![Build Status][ico-travis]][link-travis]
- 
-## Introduction 
+This is the first iteration of the project where you will find a very Object Oriented approach. We've followed the Ports & Adapters (or Hexagonal Architecture) Software Architecture using `trait`s as the domain contracts/ports in order to be implemented by the infrastructure adapters.
 
-This is a example project showing up how could you implement a HTTP API with Scala. It's used by the CodelyTV Pro course on Scala HTTP API (Spanish).
+## Contents
 
-Libraries used:
-* Akka HTTP
-* Akka HTTP testkit
+* [Endpoints](#endpoints)
+* [Libraries and implementation examples](#libraries-and-implementation-examples)
+* [Environment setup](#environment-setup)
+    * [Install the needed tools](#install-the-needed-tools)
+    * [Prepare the application environment](#prepare-the-application-environment)
+    * [Run the test and start the HTTP server](#run-the-test-and-start-the-HTTP-server)
+    * [Pre-push Git hook](#pre-push-git-hook)
+* [Logs](#logs)
+* [Deploy](#deploy)
+* [About](#about)
+* [License](#license)
 
-## How To Start
+## Endpoints
+
+One of the goals of this project is to serve as an example for the [course on Scala HTTP API (Spanish)](https://pro.codely.tv/library/api-http-con-scala-y-akka/66747/about/) illustrating how to implement several concepts you would commonly find in any production application. In order to accomplish so, we have implemented the following 5 endpoints:
+* `GET /status`: Application status health check.
+* `POST /videos`: Create new video inserting it into the database and publishing the `video_created` domain event to the message queue.
+* `GET /videos`: Obtain all the system videos.
+* `POST /users`: Create new user inserting it into the database and publishing the `user_registered` domain event to the message queue.
+* `GET /users`: Obtain all the system users.
+
+## Libraries and implementation examples
+
+| Feature                   | Library                                                     | Implementation examples    |
+| ------------------------- | ----------------------------------------------------------- | -------------------------- |
+| Build tool                | [SBT](https://www.scala-sbt.org/)                           | [Dependencies](project/Dependencies.scala), [configuration](project/Configuration.scala) & [build.sbt](build.sbt) |
+| Style formatting          | [ScalaFmt](http://scalameta.org/scalafmt/)                  | [Rules](.scalafmt.conf) |
+| Continuous Integration    | [Travis CI](https://travis-ci.org/)                         | [Travis definition](.travis.yml) |
+| HTTP server               | [Akka HTTP](https://doc.akka.io/docs/akka-http/current/)    | [Routes definition](src/main/tv/codely/scala_http_api/entry_point/Routes.scala), [server implementation](src/main/tv/codely/scala_http_api/entry_point/ScalaHttpApi.scala),<br> [Video POST controller](src/main/tv/codely/scala_http_api/entry_point/controller/video/VideoPostController.scala) & [its corresponding acceptance test](src/test/tv/codely/scala_http_api/entry_point/VideoEntryPointShould.scala) |
+| JSON marshalling          | [Spray JSON](https://github.com/spray/spray-json)           | [User](src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserJsonFormatMarshaller.scala) & [User attributes](src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserAttributesJsonFormatMarshaller.scala) marshallers |
+| Database integration      | [Doobie](http://tpolecat.github.io/doobie/)                 | [Video repository](src/main/tv/codely/scala_http_api/module/video/infrastructure/repository/DoobieMySqlVideoRepository.scala) & [its corresponding integration test](src/test/tv/codely/scala_http_api/module/video/infrastructure/repository/DoobieMySqlVideoRepositoryShould.scala) |
+| Domain events publishing  | [Akka RabbitMQ](https://github.com/NewMotion/akka-rabbitmq) | [Publisher implementation](src/main/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePublisher.scala) & [its corresponding integration test](src/test/tv/codely/scala_http_api/module/shared/infrastructure/message_broker/rabbitmq/RabbitMqMessagePublisherShould.scala) |
+| Infrastructure management | [Docker](https://www.docker.com/)                           | [Docker Compose definition](docker/docker-compose.yml) |
+| Logging                   | [ScalaLogging](https://github.com/typesafehub/scala-logging)<br> + [Logback](https://logback.qos.ch/)<br> + [Logstash encoder](https://github.com/logstash/logstash-logback-encoder) | [Logback configuration](conf/logback.xml), [logger implementation](src/main/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLogger.scala) & [its corresponding integration test](src/test/tv/codely/scala_http_api/module/shared/infrastructure/logger/scala_logging/ScalaLoggingLoggerShould.scala) |
+| Command line command      | [Scopt](https://github.com/scopt/scopt)                     | [Database tables creation script](src/main/tv/codely/scala_http_api/entry_point/cli/DbTablesCreator.scala) |
+| Distribution/deploy       | [SBT Native packager](http://sbt-native-packager.readthedocs.io/en/latest/) | [Build & deploy instructions](#Deploy) |
+| Continuous Integration    | [Travis CI](https://travis-ci.org/)                         | [Travis definition](.travis.yml) |
+| Acceptance tests          | [Akka HTTP TestKit](https://doc.akka.io/docs/akka-http/current/routing-dsl/testkit.html) | Previously specified acceptance tests |
+| Integration tests         | [ScalaTest](http://www.scalatest.org/) | Previously specified integration tests |
+| Unit tests                | [ScalaTest](http://www.scalatest.org/)<br> + [ScalaMock](http://scalamock.org/) | [Video creator use case test](src/test/tv/codely/scala_http_api/module/video/application/create/VideoCreatorShould.scala) |
+
+## Environment setup
 
 ### Install the needed tools
 1. Clone this repository: `git clone https://github.com/CodelyTV/scala-http-api.git scala-http-api`
@@ -23,16 +65,16 @@ Libraries used:
 2. Start Docker and bring up the project needed containers: `cd docker/; docker-compose up -d`
 3. Create the database tables in your Docker MySQL container: `sbt createDbTables`
 
-### Enjoy!
-1. Go into the SBT console `sbt` 
-2. Run the tests `t`
-3. Start the local server (TBD)
-4. Request for the server status (TBD) `curl`
+### Run the test and start the HTTP server
+1. Enter into the SBT console: `sbt` 
+2. Run the tests: `t`
+3. Start the local server: `run`
+4. Request for the server status: `curl http://localhost:8080/status`
 5. Take a look at the courses related to this repository (Spanish) just in case you're interested into them!
     * [Introducción a Scala](https://pro.codely.tv/library/introduccion-a-scala/63278/about/)
     * [API HTTP con Scala y Akka](https://pro.codely.tv/library/api-http-con-scala-y-akka/66747/about/)
 
-## Pre-push Git hook
+### Pre-push Git hook
 
 There's one Git hook included. It's inside the `doc/hooks` folder and it will run the `prep` SBT task before pushing to any remote.
 
@@ -40,7 +82,7 @@ This `prep` task is intended to run all the checks you consider before pushing. 
  
 You can define what this task does modifying the `prep` task in the `build.sbt` file. We like the approach of just running 1 single SBT task as the hook instead of multiple tasks because it's more efficient (the hook doesn't have to run SBT multiple times), and also because this way we can control the pre push tasks with the SBT alias defined at the `build.sbt` without altering the hooks.
  
-If you want to install this hook, just `cd doc/hooks` and run `./install-hooks.sh`.
+In order to install this hook, just `cd doc/hooks` and run `./install-hooks.sh`.
 
 ## Logs
 
@@ -73,11 +115,4 @@ We'll try to maintain this project as simple as possible, but Pull Requests are 
 
 ## License
 
-The MIT License (MIT). Please see [License File][link-license] for more information.
-
-[ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[ico-travis]: https://img.shields.io/travis/CodelyTV/scala-http-api/master.svg?style=flat-square
-
-[link-license]: LICENSE
-[link-travis]: https://travis-ci.org/CodelyTV/scala-http-api
-
+The MIT License (MIT). Please see [License](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is the first iteration of the project where you will find a very Object Ori
 * [Environment setup](#environment-setup)
     * [Install the needed tools](#install-the-needed-tools)
     * [Prepare the application environment](#prepare-the-application-environment)
-    * [Run the test and start the HTTP server](#run-the-test-and-start-the-HTTP-server)
+    * [Run the tests and start the HTTP server](#run-the-tests-and-start-the-http-server)
     * [Pre-push Git hook](#pre-push-git-hook)
 * [Logs](#logs)
 * [Deploy](#deploy)
@@ -39,7 +39,6 @@ One of the goals of this project is to serve as an example for the [course on Sc
 | ------------------------- | ----------------------------------------------------------- | -------------------------- |
 | Build tool                | [SBT](https://www.scala-sbt.org/)                           | [Dependencies](project/Dependencies.scala), [configuration](project/Configuration.scala) & [build.sbt](build.sbt) |
 | Style formatting          | [ScalaFmt](http://scalameta.org/scalafmt/)                  | [Rules](.scalafmt.conf) |
-| Continuous Integration    | [Travis CI](https://travis-ci.org/)                         | [Travis definition](.travis.yml) |
 | HTTP server               | [Akka HTTP](https://doc.akka.io/docs/akka-http/current/)    | [Routes definition](src/main/tv/codely/scala_http_api/entry_point/Routes.scala), [server implementation](src/main/tv/codely/scala_http_api/entry_point/ScalaHttpApi.scala),<br> [Video POST controller](src/main/tv/codely/scala_http_api/entry_point/controller/video/VideoPostController.scala) & [its corresponding acceptance test](src/test/tv/codely/scala_http_api/entry_point/VideoEntryPointShould.scala) |
 | JSON marshalling          | [Spray JSON](https://github.com/spray/spray-json)           | [User](src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserJsonFormatMarshaller.scala) & [User attributes](src/main/tv/codely/scala_http_api/module/user/infrastructure/marshaller/UserAttributesJsonFormatMarshaller.scala) marshallers |
 | Database integration      | [Doobie](http://tpolecat.github.io/doobie/)                 | [Video repository](src/main/tv/codely/scala_http_api/module/video/infrastructure/repository/DoobieMySqlVideoRepository.scala) & [its corresponding integration test](src/test/tv/codely/scala_http_api/module/video/infrastructure/repository/DoobieMySqlVideoRepositoryShould.scala) |
@@ -52,6 +51,7 @@ One of the goals of this project is to serve as an example for the [course on Sc
 | Acceptance tests          | [Akka HTTP TestKit](https://doc.akka.io/docs/akka-http/current/routing-dsl/testkit.html) | Previously specified acceptance tests |
 | Integration tests         | [ScalaTest](http://www.scalatest.org/) | Previously specified integration tests |
 | Unit tests                | [ScalaTest](http://www.scalatest.org/)<br> + [ScalaMock](http://scalamock.org/) | [Video creator use case test](src/test/tv/codely/scala_http_api/module/video/application/create/VideoCreatorShould.scala) |
+| Continuous Integration    | [Travis CI](https://travis-ci.org/)<br> + [SBT Coveralls](https://github.com/scoverage/sbt-coveralls) | [Travis definition](.travis.yml) |
 
 ## Environment setup
 
@@ -65,7 +65,7 @@ One of the goals of this project is to serve as an example for the [course on Sc
 2. Start Docker and bring up the project needed containers: `cd docker/; docker-compose up -d`
 3. Create the database tables in your Docker MySQL container: `sbt createDbTables`
 
-### Run the test and start the HTTP server
+### Run the tests and start the HTTP server
 1. Enter into the SBT console: `sbt` 
 2. Run the tests: `t`
 3. Start the local server: `run`

--- a/project/Configuration.scala
+++ b/project/Configuration.scala
@@ -6,7 +6,7 @@ object Configuration {
     organization := "tv.codely",
     scalaVersion := "2.12.4",
     // Custom folders path (/src/main/scala and /src/test/scala by default)
-    Compile / mainClass := Some("tv.codely.scala_http_api.ScalaHttpApi"),
+    Compile / mainClass := Some("tv.codely.scala_http_api.entry_point.ScalaHttpApi"),
     Compile / scalaSource := baseDirectory.value / "/src/main",
     Test / scalaSource := baseDirectory.value / "/src/test",
     Compile / resourceDirectory := baseDirectory.value / "conf",

--- a/project/sbt-scoverage.sbt
+++ b/project/sbt-scoverage.sbt
@@ -1,0 +1,3 @@
+// Test coverage reports. More info: https://github.com/scoverage/sbt-coveralls
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2")


### PR DESCRIPTION
* (Bonus :P) Fix for `mainClass` to run because it was moved without updating the SBT setting
*  Improved `README.md` including a brief introduction, contents index, "Endpoints", and "Libraries and implementation examples" sections
*  Add `sbt-coveralls` plugin in order to send code coverage reports to https://coveralls.io/github/CodelyTV/scala-http-api