### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ before_install:
   - sbt createDbTables
 
 script:
-  ## Execute the tests including code coverage. More info: https://github.com/scoverage/sbt-coveralls
+  - sbt prep # Check pre-push style hook in order to avoid `push --no-verify` h4ck3rs
+  # Execute the tests including code coverage. More info: https://github.com/scoverage/sbt-coveralls
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M clean coverage test
 
   # Tricks to avoid unnecessary cache updates

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     "com.typesafe.akka"          %% "akka-actor"              % Versions.akka,
     "com.typesafe.akka"          %% "akka-stream"             % Versions.akka, // Explicit dependency due to: https://bit.ly/akka-http-25
     "com.typesafe.akka"          %% "akka-http-spray-json"    % Versions.akkaHttp,
-    "org.tpolecat"               %% "doobie-core"             % "0.5.0-M13",
+    "org.tpolecat"               %% "doobie-core"             % "0.5.0-RC2",
     "mysql"                      % "mysql-connector-java"     % "5.1.45",
     "com.github.scopt"           %% "scopt"                   % "3.7.0", // Command Line Commands such as de DbTablesCreator
     "com.newmotion"              %% "akka-rabbitmq"           % "5.0.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val akka     = "2.5.8"
+    val akka     = "2.5.9"
     val akkaHttp = "10.0.11"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   )
 
   val test = Seq(
-    "org.scalatest"     %% "scalatest"         % "3.0.4"           % Test,
+    "org.scalatest"     %% "scalatest"         % "3.0.5"           % Test,
     "org.scalamock"     %% "scalamock"         % "4.0.0"           % Test,
     "com.typesafe.akka" %% "akka-testkit"      % Versions.akka     % Test,
     "com.typesafe.akka" %% "akka-http-testkit" % Versions.akkaHttp % Test

--- a/src/test/tv/codely/scala_http_api/entry_point/UserEntryPointShould.scala
+++ b/src/test/tv/codely/scala_http_api/entry_point/UserEntryPointShould.scala
@@ -8,10 +8,11 @@ import tv.codely.scala_http_api.module.user.domain.UserStub
 import tv.codely.scala_http_api.module.user.infrastructure.marshaller.UserJsValueMarshaller
 
 final class UserEntryPointShould extends AcceptanceSpec with BeforeAndAfterEach {
-  private def cleanUsersTable() =
+  private def cleanUsersTable(): Unit =
     sql"TRUNCATE TABLE users".update.run
       .transact(doobieDbConnection.transactor)
       .unsafeToFuture()
+      .map(_ => ())
       .futureValue
 
   override protected def beforeEach(): Unit = {

--- a/src/test/tv/codely/scala_http_api/entry_point/VideoEntryPointShould.scala
+++ b/src/test/tv/codely/scala_http_api/entry_point/VideoEntryPointShould.scala
@@ -8,10 +8,11 @@ import tv.codely.scala_http_api.module.video.domain.VideoStub
 import tv.codely.scala_http_api.module.video.infrastructure.marshaller.VideoJsValueMarshaller
 
 final class VideoEntryPointShould extends AcceptanceSpec with BeforeAndAfterEach {
-  private def cleanVideosTable() =
+  private def cleanVideosTable(): Unit =
     sql"TRUNCATE TABLE videos".update.run
       .transact(doobieDbConnection.transactor)
       .unsafeToFuture()
+      .map(_ => ())
       .futureValue
 
   override protected def beforeEach(): Unit = {

--- a/src/test/tv/codely/scala_http_api/module/user/infrastructure/repository/DoobieMySqlUserRepositoryShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/user/infrastructure/repository/DoobieMySqlUserRepositoryShould.scala
@@ -6,10 +6,11 @@ import doobie.implicits._
 import org.scalatest.BeforeAndAfterEach
 
 final class DoobieMySqlUserRepositoryShould extends UserIntegrationTestCase with BeforeAndAfterEach {
-  private def cleanUsersTable() =
+  private def cleanUsersTable(): Unit =
     sql"TRUNCATE TABLE users".update.run
       .transact(doobieDbConnection.transactor)
       .unsafeToFuture()
+      .map(_ => ())
       .futureValue
 
   override protected def beforeEach(): Unit = {

--- a/src/test/tv/codely/scala_http_api/module/video/infrastructure/repository/DoobieMySqlVideoRepositoryShould.scala
+++ b/src/test/tv/codely/scala_http_api/module/video/infrastructure/repository/DoobieMySqlVideoRepositoryShould.scala
@@ -6,10 +6,11 @@ import doobie.implicits._
 import org.scalatest.BeforeAndAfterEach
 
 final class DoobieMySqlVideoRepositoryShould extends VideoIntegrationTestCase with BeforeAndAfterEach {
-  private def cleanVideosTable() =
+  private def cleanVideosTable(): Unit =
     sql"TRUNCATE TABLE videos".update.run
       .transact(doobieDbConnection.transactor)
       .unsafeToFuture()
+      .map(_ => ())
       .futureValue
 
   override protected def beforeEach(): Unit = {


### PR DESCRIPTION
* Update DoobieDb from 0.5.0-M13 to 0.5.0-RC2
* Update Akka from 2.5.8 to 2.5.9: https://akka.io/blog/news/2018/01/11/akka-2.5.9-released-2.4.x-end-of-life
* Update scalatest from 3.0.4 to 3.0.5
* Run `sbt prep` command in TravisCI builds so we check pre-push style hooks in order to avoid `push --no-verify` h4ck3rs
* Fix some "Non Unit value discarded" warnings