### PR TITLE
Implement search longest video use case

### DIFF
--- a/app/main/tv/codely/mooc/api/EntryPointDependencyContainer.scala
+++ b/app/main/tv/codely/mooc/api/EntryPointDependencyContainer.scala
@@ -2,7 +2,7 @@ package tv.codely.mooc.api
 
 import tv.codely.mooc.api.controller.status.StatusGetController
 import tv.codely.mooc.api.controller.user.{UserGetController, UserPostController}
-import tv.codely.mooc.api.controller.video.{VideoGetController, VideoPostController}
+import tv.codely.mooc.api.controller.video.{LongestVideoGetController, VideoGetController, VideoPostController}
 import tv.codely.mooc.user.infrastructure.dependency_injection.UserModuleDependencyContainer
 import tv.codely.mooc.video.infrastructure.dependency_injection.VideoModuleDependencyContainer
 
@@ -15,6 +15,7 @@ final class EntryPointDependencyContainer(
   val userGetController  = new UserGetController(userDependencies.usersSearcher)
   val userPostController = new UserPostController(userDependencies.userRegistrar)
 
-  val videoGetController  = new VideoGetController(videoDependencies.videosSearcher)
-  val videoPostController = new VideoPostController(videoDependencies.videoCreator)
+  val videoGetController        = new VideoGetController(videoDependencies.videosSearcher)
+  val longestVideoGetController = new LongestVideoGetController(videoDependencies.longestVideoSearcher)
+  val videoPostController       = new VideoPostController(videoDependencies.videoCreator)
 }

--- a/app/main/tv/codely/mooc/api/Routes.scala
+++ b/app/main/tv/codely/mooc/api/Routes.scala
@@ -30,6 +30,9 @@ final class Routes(container: EntryPointDependencyContainer) {
   private val video = get {
     path("videos")(container.videoGetController.get())
   } ~
+    get {
+      path("longest_video")(container.longestVideoGetController.get())
+    } ~
     post {
       path("videos") {
         jsonBody { body =>

--- a/app/main/tv/codely/mooc/api/controller/video/LongestVideoGetController.scala
+++ b/app/main/tv/codely/mooc/api/controller/video/LongestVideoGetController.scala
@@ -1,0 +1,14 @@
+package tv.codely.mooc.api.controller.video
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.StandardRoute
+import spray.json.DefaultJsonProtocol
+import tv.codely.mooc.video.application.search.LongestVideoSearcher
+import tv.codely.mooc.video.infrastructure.marshaller.VideoJsonFormatMarshaller._
+
+final class LongestVideoGetController(searcher: LongestVideoSearcher)
+    extends SprayJsonSupport
+    with DefaultJsonProtocol {
+  def get(): StandardRoute = complete(searcher.longestVideo())
+}

--- a/app/test/tv/codely/mooc/api/VideoEntryPointShould.scala
+++ b/app/test/tv/codely/mooc/api/VideoEntryPointShould.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import doobie.implicits._
 import org.scalatest.BeforeAndAfterEach
 import spray.json._
-import tv.codely.mooc.video.domain.VideoMother
+import tv.codely.mooc.video.domain.{VideoDuration, VideoMother}
 import tv.codely.mooc.video.infrastructure.marshaller.VideoJsValueMarshaller
 import tv.codely.HttpSpec
 
@@ -45,6 +45,21 @@ final class VideoEntryPointShould extends HttpSpec with BeforeAndAfterEach {
       status shouldBe StatusCodes.OK
       contentType shouldBe ContentTypes.`application/json`
       entityAs[String].parseJson shouldBe VideoJsValueMarshaller.marshall(videos)
+    }
+  }
+
+  "return longest video" in {
+    val longestVideo  = VideoMother.random.copy(duration = VideoDuration(10))
+    val shorterVideo  = VideoMother.random.copy(duration = VideoDuration(5))
+    val shortestVideo = VideoMother.random.copy(duration = VideoDuration(1))
+    val videos        = Seq(longestVideo, shorterVideo, shortestVideo)
+
+    videos.foreach(v => videoDependencies.repository.save(v).futureValue)
+
+    getting("/longest_video") {
+      status shouldBe StatusCodes.OK
+      contentType shouldBe ContentTypes.`application/json`
+      entityAs[String].parseJson shouldBe VideoJsValueMarshaller.marshall(longestVideo)
     }
   }
 }

--- a/src/mooc/main/tv/codely/mooc/video/application/search/LongestVideoSearcher.scala
+++ b/src/mooc/main/tv/codely/mooc/video/application/search/LongestVideoSearcher.scala
@@ -1,0 +1,9 @@
+package tv.codely.mooc.video.application.search
+
+import tv.codely.mooc.video.domain.{Video, VideoRepository}
+
+import scala.concurrent.Future
+
+final class LongestVideoSearcher(repository: VideoRepository) {
+  def longestVideo(): Future[Option[Video]] = repository.findLongest()
+}

--- a/src/mooc/main/tv/codely/mooc/video/domain/VideoRepository.scala
+++ b/src/mooc/main/tv/codely/mooc/video/domain/VideoRepository.scala
@@ -6,4 +6,6 @@ trait VideoRepository {
   def all(): Future[Seq[Video]]
 
   def save(video: Video): Future[Unit]
+
+  def findLongest(): Future[Option[Video]]
 }

--- a/src/mooc/main/tv/codely/mooc/video/infrastructure/dependency_injection/VideoModuleDependencyContainer.scala
+++ b/src/mooc/main/tv/codely/mooc/video/infrastructure/dependency_injection/VideoModuleDependencyContainer.scala
@@ -2,7 +2,7 @@ package tv.codely.mooc.video.infrastructure.dependency_injection
 
 import tv.codely.shared.infrastructure.doobie.DoobieDbConnection
 import tv.codely.mooc.video.application.create.VideoCreator
-import tv.codely.mooc.video.application.search.VideosSearcher
+import tv.codely.mooc.video.application.search.{LongestVideoSearcher, VideosSearcher}
 import tv.codely.mooc.video.domain.VideoRepository
 import tv.codely.mooc.video.infrastructure.repository.DoobieMySqlVideoRepository
 import scala.concurrent.ExecutionContext
@@ -15,6 +15,7 @@ final class VideoModuleDependencyContainer(
 )(implicit executionContext: ExecutionContext) {
   val repository: VideoRepository = new DoobieMySqlVideoRepository(doobieDbConnection)
 
-  val videosSearcher: VideosSearcher = new VideosSearcher(repository)
-  val videoCreator: VideoCreator     = new VideoCreator(repository, messagePublisher)
+  val videosSearcher: VideosSearcher             = new VideosSearcher(repository)
+  val longestVideoSearcher: LongestVideoSearcher = new LongestVideoSearcher(repository)
+  val videoCreator: VideoCreator                 = new VideoCreator(repository, messagePublisher)
 }

--- a/src/mooc/main/tv/codely/mooc/video/infrastructure/repository/DoobieMySqlVideoRepository.scala
+++ b/src/mooc/main/tv/codely/mooc/video/infrastructure/repository/DoobieMySqlVideoRepository.scala
@@ -12,6 +12,12 @@ final class DoobieMySqlVideoRepository(db: DoobieDbConnection)(implicit executio
   override def all(): Future[Seq[Video]] =
     db.read(sql"SELECT video_id, title, duration_in_seconds, category, creator_id FROM videos".query[Video].to[Seq])
 
+  override def findLongest(): Future[Option[Video]] =
+    db.read(
+      sql"SELECT video_id, title, duration_in_seconds, category, creator_id FROM videos ORDER BY duration_in_seconds DESC LIMIT 1"
+        .query[Video]
+        .option)
+
   override def save(video: Video): Future[Unit] =
     sql"INSERT INTO videos(video_id, title, duration_in_seconds, category, creator_id) VALUES (${video.id}, ${video.title}, ${video.duration}, ${video.category}, ${video.creatorId})".update.run
       .transact(db.transactor)

--- a/src/mooc/test/tv/codely/mooc/video/application/search/LongestVideoSearcherShould.scala
+++ b/src/mooc/test/tv/codely/mooc/video/application/search/LongestVideoSearcherShould.scala
@@ -1,0 +1,23 @@
+package tv.codely.mooc.video.application.search
+
+import tv.codely.mooc.video.domain.VideoMother
+import tv.codely.mooc.video.infrastructure.repository.VideoRepositoryMock
+import tv.codely.shared.infrastructure.unit.UnitTestCase
+
+final class LongestVideoSearcherShould extends UnitTestCase with VideoRepositoryMock {
+  private val searcher = new LongestVideoSearcher(repository)
+
+  "return empty when there are no videos" in {
+    repositoryShouldFindLongest(Option.empty)
+
+    searcher.longestVideo().futureValue shouldBe Option.empty
+  }
+
+  "search the longest video when there is a video" in {
+    val video = VideoMother.random
+
+    repositoryShouldFindLongest(Option(video))
+
+    searcher.longestVideo().futureValue shouldBe Option(video)
+  }
+}

--- a/src/mooc/test/tv/codely/mooc/video/domain/VideoMother.scala
+++ b/src/mooc/test/tv/codely/mooc/video/domain/VideoMother.scala
@@ -8,7 +8,7 @@ import tv.codely.shared.domain.SeqMother
 object VideoMother {
   def apply(
       id: String = VideoIdMother.random.value.toString,
-      title: String = VideoTitleMother.random.value.toString,
+      title: String = VideoTitleMother.random.value,
       duration: Duration = VideoDurationMother.random.value,
       category: String = VideoCategoryMother.random.toString,
       creatorId: String = UserIdMother.random.value.toString

--- a/src/mooc/test/tv/codely/mooc/video/infrastructure/marshaller/VideoJsValueMarshaller.scala
+++ b/src/mooc/test/tv/codely/mooc/video/infrastructure/marshaller/VideoJsValueMarshaller.scala
@@ -4,18 +4,17 @@ import spray.json.{JsArray, JsNumber, JsObject, JsString}
 import tv.codely.mooc.video.domain.Video
 
 object VideoJsValueMarshaller {
+  def marshall(video: Video): JsObject = JsObject(
+    "id"                  -> JsString(video.id.value.toString),
+    "title"               -> JsString(video.title.value),
+    "duration_in_seconds" -> JsNumber(video.duration.value.toSeconds),
+    "category"            -> JsString(video.category.toString),
+    "creator_id"          -> JsString(video.creatorId.value.toString)
+  )
+
   def marshall(videos: Seq[Video]): JsArray = JsArray(
     videos
-      .map(
-        v =>
-          JsObject(
-            "id"                  -> JsString(v.id.value.toString),
-            "title"               -> JsString(v.title.value),
-            "duration_in_seconds" -> JsNumber(v.duration.value.toSeconds),
-            "category"            -> JsString(v.category.toString),
-            "creator_id"          -> JsString(v.creatorId.value.toString)
-        )
-      )
+      .map(v => marshall(v))
       .toVector
   )
 }

--- a/src/mooc/test/tv/codely/mooc/video/infrastructure/repository/DoobieMySqlVideoRepositoryShould.scala
+++ b/src/mooc/test/tv/codely/mooc/video/infrastructure/repository/DoobieMySqlVideoRepositoryShould.scala
@@ -1,7 +1,7 @@
 package tv.codely.mooc.video.infrastructure.repository
 
 import tv.codely.mooc.video.VideoIntegrationTestCase
-import tv.codely.mooc.video.domain.VideoMother
+import tv.codely.mooc.video.domain.{VideoDuration, VideoMother}
 import doobie.implicits._
 import org.scalatest.BeforeAndAfterEach
 
@@ -18,7 +18,7 @@ final class DoobieMySqlVideoRepositoryShould extends VideoIntegrationTestCase wi
     cleanVideosTable()
   }
 
-  "return an empty sequence if there're no videos" in {
+  "return an empty sequence if there are no videos" in {
     repository.all().futureValue shouldBe Seq.empty
   }
 
@@ -28,5 +28,20 @@ final class DoobieMySqlVideoRepositoryShould extends VideoIntegrationTestCase wi
     videos.foreach(v => repository.save(v).futureValue)
 
     repository.all().futureValue shouldBe videos
+  }
+
+  "return an empty option if there are no videos" in {
+    repository.findLongest().futureValue shouldBe Option.empty
+  }
+
+  "search longest video" in {
+    val longestVideo  = VideoMother.random.copy(duration = VideoDuration(10))
+    val shorterVideo  = VideoMother.random.copy(duration = VideoDuration(5))
+    val shortestVideo = VideoMother.random.copy(duration = VideoDuration(1))
+    val videos        = Seq(longestVideo, shorterVideo, shortestVideo)
+
+    videos.foreach(v => repository.save(v).futureValue)
+
+    repository.findLongest().futureValue shouldBe Option(longestVideo)
   }
 }

--- a/src/mooc/test/tv/codely/mooc/video/infrastructure/repository/VideoRepositoryMock.scala
+++ b/src/mooc/test/tv/codely/mooc/video/infrastructure/repository/VideoRepositoryMock.scala
@@ -20,4 +20,9 @@ protected[video] trait VideoRepositoryMock extends MockFactory {
     (repository.all _)
       .expects()
       .returning(Future.successful(videos))
+
+  protected def repositoryShouldFindLongest(maybeVideo: Option[Video]): Unit =
+    (repository.findLongest _)
+      .expects()
+      .returning(Future.successful(maybeVideo))
 }


### PR DESCRIPTION
Implement new use case: search longest video.

Disclaimer: My Scala knowledge is pretty limited, so there might be some non idiomatic patterns.

It was really easy to work with that codebase as the way that is structured heavily drives the design of a new use case. Also, unit and integration tests allow you gain confidence in what you're doing. So thank you a lot for that! 🙇 

Tests:
All unit tests pass and tested request locally:
```
$ curl http://localhost:8080/longest_video
{"creator_id":"1452d128-08b7-4367-b322-011eed99b98c","duration_in_seconds":10,"id":"8f15ec04-9757-4e62-bfc1-f4889084158f","category":"Screencast","title":"QwIBHk9let7nTiwDl"}%
```